### PR TITLE
feat(spinner): improve build progress display using indicatif crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,6 +739,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width 0.2.1",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1180,7 +1193,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
 dependencies = [
- "console",
+ "console 0.15.11",
  "fuzzy-matcher",
  "shell-words",
  "tempfile",
@@ -2176,6 +2189,19 @@ dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
  "serde",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
+dependencies = [
+ "console 0.16.0",
+ "portable-atomic",
+ "unicode-width 0.2.1",
+ "unit-prefix",
+ "web-time",
 ]
 
 [[package]]
@@ -3417,8 +3443,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
- "itertools 0.11.0",
+ "heck 0.5.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -3438,7 +3464,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -5151,6 +5177,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5409,6 +5441,7 @@ dependencies = [
  "http",
  "http-body-util",
  "hyper",
+ "indicatif",
  "notify",
  "oci-client 0.15.0",
  "oci-wasm 0.3.0",
@@ -6463,6 +6496,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6486,11 +6528,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -6506,6 +6565,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6516,6 +6581,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6530,10 +6601,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6548,6 +6631,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6558,6 +6647,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6572,6 +6667,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6582,6 +6683,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,7 +747,6 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.1",
  "windows-sys 0.60.2",
 ]
 
@@ -2199,7 +2198,6 @@ checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
 dependencies = [
  "console 0.16.0",
  "portable-atomic",
- "unicode-width 0.2.1",
  "unit-prefix",
  "web-time",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ docker_credential = { version = "1.3.1", default-features = false }
 etcetera = { version = "0.10.0", default-features = false }
 figment = { version = "0.10.19", default-features = false, features = ["json", "env"] }
 hyper = { version = "1.6.0", default-features = false }
+indicatif = "0.18.0"
 notify = { version = "8.0.0", default-features = false, features = ["macos_fsevent"] }
 oci-client = { version = "0.15.0", default-features = false, features = ["rustls-tls", "rustls-tls-native-roots"]}
 oci-wasm = { version = "0.3.0", default-features = false, features = ["rustls-tls"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ docker_credential = { version = "1.3.1", default-features = false }
 etcetera = { version = "0.10.0", default-features = false }
 figment = { version = "0.10.19", default-features = false, features = ["json", "env"] }
 hyper = { version = "1.6.0", default-features = false }
-indicatif = "0.18.0"
+indicatif = { version = "0.18.0", default-features = false }
 notify = { version = "8.0.0", default-features = false, features = ["macos_fsevent"] }
 oci-client = { version = "0.15.0", default-features = false, features = ["rustls-tls", "rustls-tls-native-roots"]}
 oci-wasm = { version = "0.3.0", default-features = false, features = ["rustls-tls"] }

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -131,7 +131,7 @@ impl CliCommand for DevCommand {
         spinner.set_style(
             ProgressStyle::default_spinner()
                 .template("{spinner:.green} {msg}")
-                .unwrap(),
+                .context("failed to create spinner")?,
         );
         spinner.set_message("Building component...");
         spinner.enable_steady_tick(Duration::from_millis(100));
@@ -338,7 +338,7 @@ impl CliCommand for DevCommand {
         dev_spinner.set_style(
             ProgressStyle::default_spinner()
                 .template("{spinner:.green} {msg}")
-                .unwrap(),
+                .context("failed to create spinner")?,
         );
 
         loop {

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -5,6 +5,7 @@ use std::{
         Arc,
         atomic::{AtomicBool, Ordering},
     },
+    time::Duration,
 };
 
 use anyhow::{Context as _, ensure};
@@ -12,6 +13,7 @@ use base64::Engine;
 use clap::Args;
 use etcetera::AppStrategy as _;
 use hyper::server::conn::http1;
+use indicatif::{ProgressBar, ProgressStyle};
 use notify::{
     Event as NotifyEvent, RecursiveMode, Watcher,
     event::{EventKind, ModifyKind},
@@ -125,9 +127,15 @@ impl CliCommand for DevCommand {
             debug!("no recommendations found for project tools");
         }
 
-        // TODO(#17): spinner
-        debug!("building component");
-        // Build component
+        let spinner = ProgressBar::new_spinner();
+        spinner.set_style(
+            ProgressStyle::default_spinner()
+                .template("{spinner:.green} {msg}")
+                .unwrap(),
+        );
+        spinner.set_message("Building component...");
+        spinner.enable_steady_tick(Duration::from_millis(100));
+
         let artifact_path = match build_component(&self.project_dir, ctx, &config).await {
             // Edge case where the build was successful, but the artifact path in the config is different
             // than the one returned by the build process.
@@ -138,16 +146,19 @@ impl CliCommand for DevCommand {
                     .and_then(|b| b.artifact_path.as_ref())
                     .is_some_and(|p| p != &build_result.artifact_path) =>
             {
+                spinner.finish_with_message("✅ Component built successfully");
                 warn!(path = ?build_result.artifact_path, "component built successfully, but artifact path in config is different");
                 // Ensure the artifact path is set in the config
                 build_result.artifact_path
             }
             // Use the build result artifact path if the config does not specify one
             Ok(build_result) => {
+                spinner.finish_with_message("✅ Component built successfully");
                 debug!(path = ?build_result.artifact_path, "component built successfully, using as artifact path");
                 build_result.artifact_path
             }
             Err(e) => {
+                spinner.finish_with_message("❌ Build failed");
                 // TODO(#18): Support continuing, npm start works like that.
                 error!("failed to build component, will not start dev session");
                 error!("{e}");
@@ -322,29 +333,44 @@ impl CliCommand for DevCommand {
         info!("development session started successfully");
         info!(address = self.address, "listening for HTTP requests");
 
+        // Create a single spinner for the entire dev session
+        let dev_spinner = ProgressBar::new_spinner();
+        dev_spinner.set_style(
+            ProgressStyle::default_spinner()
+                .template("{spinner:.green} {msg}")
+                .unwrap(),
+        );
+
         loop {
             info!("watching for file changes (press Ctrl+c to stop)...");
             select! {
                 // Process a file change/reload
                 _ = reload_rx.recv() => {
-                    info!("rebuilding component after file changed ...");
                     pause_watch.store(true, Ordering::SeqCst);
+
+                    dev_spinner.set_message("Rebuilding component...");
+                    dev_spinner.enable_steady_tick(Duration::from_millis(100));
+
+                    info!("rebuilding component after file changed ...");
 
                     // TODO(IMPORTANT): ensure that this calls the build pre-post hooks
                     // TODO(#21): Skip wit fetch if no .wit change
                     // TODO(#22): Typescript: Skip install if no package.json change
-                    match build_component(
-                        &self.project_dir,
-                        ctx,
-                        &config,
-                    )
-                    .await {
+                    let rebuild_result = dev_spinner.suspend(|| async {
+                        build_component(
+                            &self.project_dir,
+                            ctx,
+                            &config,
+                        ).await
+                    }).await;
+
+                    match rebuild_result {
                         Ok(build_result) => {
                             // Use the new artifact path from the build result
                             let artifact_path = build_result.artifact_path;
+                            dev_spinner.set_message("Deploying rebuilt component...");
                             info!(path = %artifact_path.display(), "component rebuilt successfully");
 
-                            info!("deploying rebuilt component ...");
                             let wasm_bytes = tokio::fs::read(&artifact_path)
                                 .await
                                 .context("failed to read artifact file")?;
@@ -353,14 +379,18 @@ impl CliCommand for DevCommand {
                                 .context("failed to prepare component")?;
                             component_tx.send_replace(Arc::new(component));
 
+                            dev_spinner.finish_with_message("✅ Component rebuilt and deployed successfully");
+                            dev_spinner.reset();
+
                             // Avoid jitter with reloads by pausing the watcher for a short time
                             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
                             // Make sure that the reload channel is empty before unpausing the watcher
                             let _ = reload_rx.try_recv();
                             pause_watch.store(false, Ordering::SeqCst);
-                            info!("component deployed");
                         }
                         Err(e) => {
+                            dev_spinner.finish_with_message("❌ Rebuild failed");
+                            dev_spinner.reset();
                             info!("failed to build component, will retry on next file change");
                             // TODO(#23): This doesn't include color output
                             // This nicely formats the error message


### PR DESCRIPTION
Closes #17

## Feature or Problem
This PR adds a build progress spinner to `wash dev` using the `indicatif` crate.  
The spinner provides visual feedback during component builds, improving the developer experience by making it clear when a build is in progress.  

## Related Issues
- #17 — Add spinner to indicate build progress in `wash dev`

## Release Information
Targeting the next release.

## Consumer Impact
- `wash dev` will now display a build spinner during component builds.
- No functional changes to build or deploy logic.

## Testing

### Acceptance or Integration
- No changes required to existing acceptance or integration tests.

### Manual Verification
- Ran `wash dev` on a sample Rust project:
  - Spinner appears during the initial build.
  - Spinner clears upon completion and shows the final build message.
