### PR TITLE
fix(oauth): update Go version to 1.24.0 to support the tool directive

### DIFF
--- a/plugins/oauth/go.mod
+++ b/plugins/oauth/go.mod
@@ -1,6 +1,6 @@
 module github.com/wasmcloud/wash/plugins/oauth
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/julienschmidt/httprouter v1.3.0


### PR DESCRIPTION
## Feature or Problem

This PR is to upgrade the Go version in the plugins/oauth module to 1.24.0.

The previous version (1.23.0) did not officially support the tool directive, which caused build failures. This change resolves that issue by aligning the module with the correct Go version, ensuring the project builds correctly and the tool directive is properly supported.

## Related Issues

Fixes #39 

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
