### PR TITLE
feat(dev): support TLS dev HTTPS serving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3168,6 +3168,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3723,6 +3733,19 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -5434,7 +5457,7 @@ dependencies = [
 
 [[package]]
 name = "wash"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5454,7 +5477,10 @@ dependencies = [
  "notify",
  "oci-client 0.15.0",
  "oci-wasm 0.3.0",
+ "rcgen",
  "reqwest",
+ "rustls 0.23.27",
+ "rustls-pemfile",
  "semver",
  "serde",
  "serde_json",
@@ -5462,6 +5488,7 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
+ "tokio-rustls 0.26.2",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -7073,6 +7100,15 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 categories = ["wasm", "command-line-utilities"]
 description = "The Wasm Shell (wash) for developing and publishing Wasm components"
 keywords = ["webassembly", "wasm", "component", "wash", "cli"]
@@ -41,6 +41,8 @@ notify = { version = "8.0.0", default-features = false, features = ["macos_fseve
 oci-client = { version = "0.15.0", default-features = false, features = ["rustls-tls", "rustls-tls-native-roots"]}
 oci-wasm = { version = "0.3.0", default-features = false, features = ["rustls-tls"] }
 reqwest = { version = "0.12.20", default-features = false, features = ["json", "rustls-tls"] }
+rustls = { version = "0.23", default-features = false, features = ["std", "tls12"] }
+rustls-pemfile = { version = "2.2", default-features = false, features = ["std"] }
 semver = { version = "1.0.26", default-features = false }
 serde = { version = "1.0.219", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.140", default-features = false, features = ["std"] }
@@ -48,6 +50,7 @@ sha2 = { version = "0.10.8", default-features = false }
 tar = { version = "0.4", default-features = false }
 tempfile = { version = "3.15.0", default-features = false }
 tokio = { version = "1.45.1", default-features = false, features = ["full"] }
+tokio-rustls = { version = "0.26", default-features = false }
 tracing = { version = "0.1.41", default-features = false, features = ["attributes"] }
 tracing-subscriber = { version = "0.3.19", default-features = false, features = ["env-filter", "ansi", "time", "json"] }
 url = { version = "2.5", default-features = false }
@@ -65,6 +68,7 @@ wit-component = { version = "0.235.0", default-features = false }
 bytes = { version = "1", default-features = false }
 http = { version = "1.3.1", default-features = false }
 http-body-util = { version = "0.1.3", default-features = false }
+rcgen = { version = "0.13", default-features = false, features = ["crypto", "ring", "pem"] }
 tempfile = { version = "3.0", default-features = false }
 tokio = { version = "1.45.1", default-features = false, features = ["full"] }
 

--- a/crates/wash/src/cli/plugin.rs
+++ b/crates/wash/src/cli/plugin.rs
@@ -188,6 +188,7 @@ impl<'a> CliCommand for ComponentPluginCommand<'a> {
                                         store.as_context_mut(),
                                         pre,
                                         req,
+                                        wasmtime_wasi_http::bindings::http::types::Scheme::Http,
                                     )
                                     .await
                                 }

--- a/plugins/inspect/wit/deps/wasmcloud-wash-0.0.1/package.wit
+++ b/plugins/inspect/wit/deps/wasmcloud-wash-0.0.1/package.wit
@@ -184,8 +184,7 @@ interface types {
     ///
     /// The lifecycle of this command is tied to the CLI execution context. This means it will
     /// continue to run until the CLI session ends and then be killed.
-    /// @since(version = 0.0.2)
-    /// host-exec-background: func(bin: string, args: list<string>) -> result<_, string>;
+    host-exec-background: func(bin: string, args: list<string>) -> result<_, string>;
     /// TODO(IMPORTANT): No wasi:logging, fix this up for how we want to do output
     /// User visible Output
     /// For debugging, see wasi:logging


### PR DESCRIPTION
## Feature or Problem
This PR allows for supplying a TLS cert and key to the `wash dev` command, optionally a tls-ca as well, so that `wash dev` can be used with test programs that require HTTPS connections (some MCP clients require this.)

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
