### PR TITLE
feat: enhance TinyGo build flag support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ tests/output
 # Ignore Rust target directory
 target/
 
+# Ignore worktrees
+worktrees/
+
 # AI things
 .claude
 CLAUDE.md

--- a/crates/wash/src/cli/component_build.rs
+++ b/crates/wash/src/cli/component_build.rs
@@ -676,12 +676,40 @@ impl ComponentBuilder {
                 "WIT directory does not exist, skipping WIT-related flags: {}",
                 wit_dir.display()
             );
-        } // Apply garbage collector - now uses explicit default from config
+        }
+
+        // Apply garbage collector - now uses explicit default from config
         tinygo_args.push("-gc".to_string());
         tinygo_args.push(tinygo_config.gc.to_string());
 
-        // Add debug settings - disable by default for smaller builds
-        tinygo_args.push("-no-debug".to_string());
+        // Apply scheduler - now uses explicit default from config
+        tinygo_args.push("-scheduler".to_string());
+        tinygo_args.push(tinygo_config.scheduler.to_string());
+
+        // Apply optimization level
+        tinygo_args.push("-opt".to_string());
+        tinygo_args.push(tinygo_config.opt.to_string());
+
+        // Apply panic strategy
+        tinygo_args.push("-panic".to_string());
+        tinygo_args.push(tinygo_config.panic.to_string());
+
+        // Apply build tags if configured
+        if !tinygo_config.tags.is_empty() {
+            tinygo_args.push("-tags".to_string());
+            tinygo_args.push(tinygo_config.tags.join(","));
+        }
+
+        // Apply stack size if configured
+        if let Some(stack_size) = &tinygo_config.stack_size {
+            tinygo_args.push("-stack-size".to_string());
+            tinygo_args.push(stack_size.clone());
+        }
+
+        // Add debug settings - configurable via no_debug flag
+        if tinygo_config.no_debug {
+            tinygo_args.push("-no-debug".to_string());
+        }
 
         // Add any additional build flags if configured
         for flag in &tinygo_config.build_flags {

--- a/crates/wash/src/component_build.rs
+++ b/crates/wash/src/component_build.rs
@@ -183,6 +183,26 @@ pub struct TinyGoBuildConfig {
     #[serde(default = "default_tinygo_gc")]
     pub gc: TinyGoGarbageCollector,
 
+    /// Optimization level (default: "z")
+    #[serde(default = "default_tinygo_opt")]
+    pub opt: String,
+
+    /// Panic strategy (default: "print")
+    #[serde(default = "default_tinygo_panic")]
+    pub panic: String,
+
+    /// Build tags (default: empty)
+    #[serde(default)]
+    pub tags: Vec<String>,
+
+    /// Strip debug information (default: true)
+    #[serde(default = "default_tinygo_no_debug")]
+    pub no_debug: bool,
+
+    /// Goroutine stack size (optional)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stack_size: Option<String>,
+
     /// The WIT package to use for TinyGo builds, if not provided
     /// it will assume only one WIT package is defined in the project
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -203,6 +223,11 @@ impl Default for TinyGoBuildConfig {
             disable_go_generate: false,
             scheduler: default_tinygo_scheduler(),
             gc: default_tinygo_gc(),
+            opt: default_tinygo_opt(),
+            panic: default_tinygo_panic(),
+            tags: Vec::new(),
+            no_debug: default_tinygo_no_debug(),
+            stack_size: None,
             wit_package: None,
             wit_world: None,
         }
@@ -219,6 +244,18 @@ fn default_tinygo_scheduler() -> TinyGoScheduler {
 
 fn default_tinygo_gc() -> TinyGoGarbageCollector {
     TinyGoGarbageCollector::Conservative
+}
+
+fn default_tinygo_opt() -> String {
+    "z".to_string()
+}
+
+fn default_tinygo_panic() -> String {
+    "print".to_string()
+}
+
+fn default_tinygo_no_debug() -> bool {
+    true
 }
 
 /// TypeScript-specific build configuration with explicit defaults


### PR DESCRIPTION
## Summary

This PR implements comprehensive TinyGo build configuration support as requested in #50, adding missing important build flags that were available in the `tinygo build` command but not configurable through wash.

## Changes

### New TinyGo Configuration Fields
Added the following fields to `TinyGoBuildConfig`:

- **`opt`**: Optimization level (0, 1, 2, s, z) - defaults to "z"
- **`panic`**: Panic strategy (print, trap) - defaults to "print"  
- **`tags`**: Space-separated list of extra build tags - defaults to empty
- **`no_debug`**: Strip debug information - defaults to true (configurable now vs hardcoded)
- **`stack_size`**: Goroutine stack size - optional configuration

### Build Command Integration
Updated `build_tinygo_component` method to apply all new flags:
- `-opt` flag with configured optimization level
- `-panic` flag with panic strategy
- `-tags` flag with comma-joined build tags (when configured)
- `-stack-size` flag with stack size (when configured)  
- `-no-debug` flag conditionally applied based on `no_debug` setting

### Configuration Example
```json
{
  "build": {
    "tinygo": {
      "target": "wasip2",
      "gc": "conservative", 
      "scheduler": "asyncify",
      "opt": "2",
      "panic": "print",
      "tags": ["debug", "custom"],
      "no_debug": false,
      "stack_size": "8192",
      "build_flags": ["--custom-flag", "value"]
    }
  }
}
```

## Test plan
- [x] All existing tests pass
- [x] Code formatted with `cargo fmt`
- [x] No clippy warnings
- [x] TinyGo build command construction properly includes new flags
- [x] Default values maintained for backward compatibility

## Benefits
- **Flexibility**: Users can fine-tune TinyGo builds for specific needs
- **Consistency**: All language toolchains (Rust, TinyGo, TypeScript) now have similar configuration capabilities  
- **Performance**: Users can choose appropriate optimization levels and panic strategies
- **Debugging**: Users can control debug information inclusion
- **Backward Compatible**: Existing configurations continue to work unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)