### PR TITLE
fix: default to --release mode for Rust built components

### DIFF
--- a/crates/wash/src/component_build.rs
+++ b/crates/wash/src/component_build.rs
@@ -56,7 +56,12 @@ pub struct RustBuildConfig {
     pub cargo_flags: Vec<String>,
 
     /// Release mode (default: false)
-    #[serde(default)]
+    /// Defaulting to release mode == false leads to a 6.6MB file size in the `http-hello-world` example
+    /// instead of a 237KB file size.
+    /// The work-around is known and likely to be fixed Soon TM,
+    /// see https://github.com/serde-rs/serde/issues/2815#issuecomment-2329810263
+    /// for why the function `make_true` below is needed.
+    #[serde(default = "make_true")]
     pub release: bool,
 
     /// Features to enable (default: empty)
@@ -68,13 +73,17 @@ pub struct RustBuildConfig {
     pub no_default_features: bool,
 }
 
+fn make_true() -> bool {
+    true
+}
+
 impl Default for RustBuildConfig {
     fn default() -> Self {
         Self {
             custom_command: None,
             target: default_rust_target(),
             cargo_flags: Vec::new(),
-            release: false,
+            release: true,
             features: Vec::new(),
             no_default_features: false,
         }


### PR DESCRIPTION
## Feature or Problem

Rust components are built in `debug` mode, leading to horribly bloated file sizes (6.6MB vs 237KB).

## Related Issues
wasmCloud/wasmCloud#4958 

## Release Information
next

## Consumer Impact
Faster components by default

## Testing



### Unit Test(s)


### Acceptance or Integration


### Manual Verification
```bash
$cargo run build ./http-hello-world/ && ls -lah http-hello-world/target/wasm32-wasip2/*
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.41s
     Running `target/debug/wash build ./http-hello-world/`
2025-08-29T22:41:26.572651Z  INFO building component path="./http-hello-world/"
cargo_args: ["build", "--release", "--target", "wasm32-wasip2"]
2025-08-29T22:41:32.865983Z  INFO cargo build --release --target wasm32-...

http-hello-world/target/wasm32-wasip2/release:
...
.rw-r--r--   145 miguel 29 Aug 16:41  http_hello_world.d
.rw-r--r--  237k miguel 29 Aug 16:41  http_hello_world.wasm
```