### PR TITLE
fix/template locality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5466,7 +5466,7 @@ dependencies = [
 
 [[package]]
 name = "wash"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash"
-version = "1.0.0-beta.4"
+version = "1.0.0-beta.5"
 categories = ["wasm", "command-line-utilities"]
 description = "The Wasm Shell (wash) for developing and publishing Wasm components"
 keywords = ["webassembly", "wasm", "component", "wash", "cli"]

--- a/crates/wash/src/cli/mod.rs
+++ b/crates/wash/src/cli/mod.rs
@@ -431,7 +431,7 @@ impl CliContext {
                 ?config_path,
                 "config file not found, creating with defaults"
             );
-            generate_default_config(&config_path, false).await?;
+            generate_default_config(&config_path, false, true).await?;
         }
 
         // Load the configuration using the hierarchical configuration system

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -36,7 +36,7 @@ pub struct Config {
     pub build: Option<BuildConfig>,
 
     /// Template configuration for new project creation (default: wasmCloud templates)
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub templates: Vec<NewTemplate>,
 
     /// WIT dependency management configuration (default: empty/optional)
@@ -254,7 +254,11 @@ pub fn local_config_path(project_dir: &Path) -> PathBuf {
 
 /// Generate a default configuration file with all explicit defaults
 /// This is useful for `wash config init` command
-pub async fn generate_default_config(path: &Path, force: bool) -> Result<()> {
+pub async fn generate_default_config(
+    path: &Path,
+    force: bool,
+    include_templates: bool,
+) -> Result<()> {
     // Don't overwrite existing config unless force is specified
     if path.exists() && !force {
         bail!(
@@ -263,7 +267,11 @@ pub async fn generate_default_config(path: &Path, force: bool) -> Result<()> {
         );
     }
 
-    let default_config = Config::default();
+    let default_config = if include_templates {
+        Config::default_with_templates()
+    } else {
+        Config::default()
+    };
     save_config(&default_config, path).await?;
 
     info!(config_path = %path.display(), "Generated default configuration");


### PR DESCRIPTION
- **fix(config): store templates in global not project**
- **release(wash): v1.0.0-beta.5**

## Feature or Problem
This PR fixes an issue with deserializing templates that ensures that missing templates don't throw an error and instead default to an empty list. It also adds the `--global` flag to the `wash config init` command which ensures that we're initializing configuration in the local project context by default.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
