### PR TITLE
Chore/13 enable clippy deny warnings

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -72,10 +72,8 @@ jobs:
         run: |
           cargo +nightly fmt -- --check
       - name: Lint
-        # TODO(#13): Deny warnings for code quality
-        # cargo clippy --workspace -- -D warnings
         run: |
-          cargo clippy --workspace
+          cargo clippy --workspace -- -D warnings
       - name: Check for unused dependencies
         run: |
           cargo machete

--- a/crates/wash/src/cli/inspect.rs
+++ b/crates/wash/src/cli/inspect.rs
@@ -61,11 +61,11 @@ impl CliCommand for InspectCommand {
 
                     // Load project config and build the component
                     let config = ctx
-                        .ensure_config(Some(&path))
+                        .ensure_config(Some(path))
                         .await
                         .context("Failed to load project configuration")?;
 
-                    let build_result = build_component(&path, ctx, &config)
+                    let build_result = build_component(path, ctx, &config)
                         .await
                         .context("Failed to build component from project directory")?;
 


### PR DESCRIPTION
## Feature or Problem
The current CI workflow has cargo clippy --workspace -- -D warnings commented out. This means that code with clippy warnings can still pass the linting job and be merged into the main branch. This PR addresses this problem by uncommenting that command to ensure that all code merged has zero clippy warnings, thereby improving overall code quality and maintainability.
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues

#13 

<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information

This is a maintenance and quality-of-life improvement for the project. It doesn't introduce any new features or fix user-facing bugs. This PR only affects our internal CI workflow and is intended to improve code quality and maintainability.
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
