### PR TITLE
feat: add color output in build error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1857,6 +1868,15 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
@@ -3322,7 +3342,7 @@ checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi",
+ "hermit-abi 0.5.2",
  "pin-project-lite",
  "rustix 1.0.7",
  "tracing",
@@ -5469,6 +5489,7 @@ name = "wash"
 version = "1.0.0-beta.5"
 dependencies = [
  "anyhow",
+ "atty",
  "base64 0.22.1",
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 anyhow = { version = "1.0.98", default-features = false }
+atty = { version= "0.2", default-features = false }
 base64 = { version = "0.22", default-features = false, features = ["std"] }
 clap = { version = "4.5.40", default-features = false, features = ["derive", "env", "help", "color", "suggestions", "wrap_help", "cargo", "string"] }
 clap_complete = { version = "4.5.40", default-features = false }

--- a/crates/wash/src/cli/component_build.rs
+++ b/crates/wash/src/cli/component_build.rs
@@ -1,11 +1,13 @@
 //! CLI command for building components, including Rust, TinyGo, and TypeScript projects
 
 use std::{
+    env,
     path::{Path, PathBuf},
     time::{Duration, Instant},
 };
 
 use anyhow::{Context as _, bail};
+use atty;
 use clap::Args;
 use etcetera::AppStrategy;
 use indicatif::{ProgressBar, ProgressStyle};
@@ -498,6 +500,15 @@ impl ComponentBuilder {
         // Apply no-default-features if configured
         if rust_config.no_default_features {
             cargo_args.push("--no-default-features".to_string());
+        }
+
+        // Apply colored logs if not configured
+        if atty::is(atty::Stream::Stderr) && env::var("CARGO_TERM_COLOR").is_err() {
+            let no_color = env::var("NO_COLOR").unwrap_or_default();
+            if no_color.is_empty() || no_color == "0" {
+                cargo_args.push("--color".to_string());
+                cargo_args.push("always".to_string());
+            }
         }
 
         // Add any additional cargo flags if configured

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -549,7 +549,6 @@ impl CliCommand for DevCommand {
                         }
                         Err(e) => {
                             info!("failed to build component, will retry on next file change");
-                            // TODO(#23): This doesn't include color output
                             // This nicely formats the error message
                             error!("{e}");
                             // If the build fails, we pause the watcher to prevent further reloads


### PR DESCRIPTION
## Feature or Problem
As described in [issue 23](https://github.com/wasmCloud/wash/issues/23) build errors occuring with the dev command do not output any colors. The approach taken here is to first check if atty and then depending on `NO_COLOR` is set the environment variable `CARGO_TERM_COLOR` is set to `always`.

## Related Issues
[Issue 23](https://github.com/wasmCloud/wash/issues/23)

## Release Information
`next`

## Consumer Impact
If no color output for dev build messages is desired `NO_COLOR=1` needs to be set.

## Testing
No tests were added. The output was tested manually.

### Unit Test(s)
None

### Acceptance or Integration
None

### Manual Verification
Ran wash dev /path/to/example/component with `NO_COLOR=1`, `NO_COLOR=0` and NO_COLOR not set. The component contained build errors and the colors were visible only when `NO_COLOR=0` or `NO_COLOR` was not set.
