### PR TITLE
refactor: rename artifact-path to component-path

### DIFF
--- a/.wash/config.json
+++ b/.wash/config.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "artifact_path": "target/debug/wash",
+    "component_path": "target/debug/wash",
     "rust": {
       "target": "aarch64-apple-darwin"
     }

--- a/crates/wash/src/cli/component_build.rs
+++ b/crates/wash/src/cli/component_build.rs
@@ -34,8 +34,8 @@ pub struct ComponentBuildCommand {
     build_config: Option<PathBuf>,
 
     /// The expected path to the built Wasm component artifact
-    #[clap(long = "artifact-path")]
-    artifact_path: Option<PathBuf>,
+    #[clap(long = "component-path")]
+    component_path: Option<PathBuf>,
 
     /// Skip fetching WIT dependencies, useful for offline builds
     #[clap(long = "skip-fetch")]
@@ -61,10 +61,10 @@ impl CliCommand for ComponentBuildCommand {
         Ok(CommandOutput::ok(
             format!(
                 "Successfully built component at: {}",
-                result.artifact_path.display()
+                result.component_path.display()
             ),
             Some(serde_json::json!({
-                "artifact_path": result.artifact_path,
+                "component_path": result.component_path,
                 "project_type": result.project_type,
                 "project_path": self.project_path,
             })),
@@ -83,7 +83,7 @@ impl CliCommand for ComponentBuildCommand {
 #[derive(Debug, Clone)]
 pub struct ComponentBuildResult {
     /// Path to the built component artifact
-    pub artifact_path: PathBuf,
+    pub component_path: PathBuf,
     /// Type of project that was built
     pub project_type: ProjectType,
     /// Original project path
@@ -226,7 +226,7 @@ impl ComponentBuilder {
 
         info!(path = ?self.project_path.display(), "building component");
         // Build the component using the language toolchain
-        let artifact_path = match project_type {
+        let component_path = match project_type {
             ProjectType::Rust => self.build_rust_component(config).await?,
             ProjectType::Go => self.build_tinygo_component(config).await?,
             ProjectType::TypeScript => self.build_typescript_component(config).await?,
@@ -241,16 +241,16 @@ impl ComponentBuilder {
         // Write project configuration
         generate_project_config(&self.project_path, &project_type, config).await?;
 
-        // Attempt to canonicalize the artifact path
-        let artifact_path = artifact_path.canonicalize().unwrap_or(artifact_path);
+        // Attempt to canonicalize the component path
+        let component_path = component_path.canonicalize().unwrap_or(component_path);
 
         debug!(
-            artifact_path = ?artifact_path.display(),
+            component_path = ?component_path.display(),
             "component build completed successfully",
         );
 
         Ok(ComponentBuildResult {
-            artifact_path,
+            component_path,
             project_type,
             project_path: self.project_path.clone(),
         })
@@ -527,18 +527,22 @@ impl ComponentBuilder {
         let stdout = String::from_utf8_lossy(&output.stdout);
         debug!(stdout = %stdout, "cargo build output");
 
-        if let Some(artifact_path) = config.build.as_ref().and_then(|b| b.artifact_path.as_ref()) {
-            if artifact_path.exists() {
-                debug!(artifact_path = %artifact_path.display(), "found component artifact at specified path");
-                return Ok(artifact_path.to_owned());
-            } else if self.project_path.join(artifact_path).exists() {
-                let abs_path = self.project_path.join(artifact_path);
-                debug!(artifact_path = %abs_path.display(), "found component artifact at specified path relative to project root");
+        if let Some(component_path) = config
+            .build
+            .as_ref()
+            .and_then(|b| b.component_path.as_ref())
+        {
+            if component_path.exists() {
+                debug!(component_path = %component_path.display(), "found component artifact at specified path");
+                return Ok(component_path.to_owned());
+            } else if self.project_path.join(component_path).exists() {
+                let abs_path = self.project_path.join(component_path);
+                debug!(component_path = %abs_path.display(), "found component artifact at specified path relative to project root");
                 return Ok(abs_path);
             } else {
                 bail!(
-                    "specified artifact path does not exist: {}",
-                    artifact_path.display()
+                    "specified component path does not exist: {}",
+                    component_path.display()
                 )
             }
         }
@@ -563,7 +567,7 @@ impl ComponentBuilder {
         {
             let path = entry.path();
             if path.extension().and_then(|s| s.to_str()) == Some("wasm") {
-                debug!(artifact_path = %path.display(), "found component artifact");
+                debug!(component_path = %path.display(), "found component artifact");
                 return Ok(path);
             }
         }
@@ -637,10 +641,10 @@ impl ComponentBuilder {
             let Some(wit_world) = &tinygo_config.wit_world else {
                 // Generate project config to ensure .wash/config.json exists with placeholder
                 let mut config_with_placeholder = config.clone();
-                let artifact_path_relative = PathBuf::from("build/output.wasm");
+                let component_path_relative = PathBuf::from("build/output.wasm");
 
                 if let Some(build_config) = &mut config_with_placeholder.build {
-                    build_config.artifact_path = Some(artifact_path_relative.clone());
+                    build_config.component_path = Some(component_path_relative.clone());
                     if let Some(tinygo_config) = &mut build_config.tinygo {
                         tinygo_config.wit_world = Some("PLACEHOLDER_WIT_WORLD".to_string());
                     }
@@ -649,7 +653,7 @@ impl ComponentBuilder {
                     tinygo_config.wit_world = Some("PLACEHOLDER_WIT_WORLD".to_string());
                     config_with_placeholder.build = Some(crate::component_build::BuildConfig {
                         tinygo: Some(tinygo_config),
-                        artifact_path: Some(artifact_path_relative),
+                        component_path: Some(component_path_relative),
                         ..Default::default()
                     });
                 }
@@ -780,7 +784,7 @@ impl ComponentBuilder {
             );
         }
 
-        debug!(artifact_path = %output_file.display(), "found component artifact");
+        debug!(component_path = %output_file.display(), "found component artifact");
         Ok(output_file)
     }
 
@@ -901,21 +905,25 @@ impl ComponentBuilder {
             );
         }
 
-        // If an artifact path is specified, find the Wasm artifact there
-        if let Some(artifact_path) = config.build.as_ref().and_then(|b| b.artifact_path.as_ref()) {
-            if artifact_path.exists() {
-                debug!(artifact_path = %artifact_path.display(), "found component artifact at specified path");
-                Ok(artifact_path.to_owned())
-            } else if self.project_path.join(artifact_path).exists() {
+        // If an component path is specified, find the Wasm artifact there
+        if let Some(component_path) = config
+            .build
+            .as_ref()
+            .and_then(|b| b.component_path.as_ref())
+        {
+            if component_path.exists() {
+                debug!(component_path = %component_path.display(), "found component artifact at specified path");
+                Ok(component_path.to_owned())
+            } else if self.project_path.join(component_path).exists() {
                 debug!(
-                    artifact_path = %artifact_path.display(),
+                    component_path = %component_path.display(),
                     "found component artifact at specified path relative to project root"
                 );
-                Ok(self.project_path.join(artifact_path))
+                Ok(self.project_path.join(component_path))
             } else {
                 bail!(
-                    "specified artifact path does not exist: {}",
-                    artifact_path.display()
+                    "specified component path does not exist: {}",
+                    component_path.display()
                 )
             }
         } else {
@@ -940,7 +948,7 @@ impl ComponentBuilder {
                     {
                         let path = entry.path();
                         if path.extension().and_then(|s| s.to_str()) == Some("wasm") {
-                            debug!(artifact_path = %path.display(), "found component artifact");
+                            debug!(component_path = %path.display(), "found component artifact");
                             return Ok(path);
                         }
                     }
@@ -948,7 +956,7 @@ impl ComponentBuilder {
             }
 
             bail!(
-                "No .wasm file found in common locations: dist/, build/, out/, or project root. Specify --artifact-path to override this behavior.",
+                "No .wasm file found in common locations: dist/, build/, out/, or project root. Specify --component-path to override this behavior.",
             )
         }
     }

--- a/crates/wash/src/cli/inspect.rs
+++ b/crates/wash/src/cli/inspect.rs
@@ -69,10 +69,10 @@ impl CliCommand for InspectCommand {
                         .await
                         .context("Failed to build component from project directory")?;
 
-                    info!(artifact_path = ?build_result.artifact_path, "Component built successfully");
+                    info!(component_path = ?build_result.component_path, "Component built successfully");
 
                     // Read the built component
-                    tokio::fs::read(&build_result.artifact_path)
+                    tokio::fs::read(&build_result.component_path)
                         .await
                         .context("Failed to read built component file")?
                 } else {

--- a/crates/wash/src/cli/plugin.rs
+++ b/crates/wash/src/cli/plugin.rs
@@ -419,7 +419,7 @@ impl TestCommand {
             let built_path = build_component(&self.plugin, ctx, &config)
                 .await
                 .context("Failed to build component from directory")?;
-            tokio::fs::read(&built_path.artifact_path)
+            tokio::fs::read(&built_path.component_path)
                 .await
                 .context("Failed to read built component file")?
         } else {

--- a/crates/wash/src/component_build.rs
+++ b/crates/wash/src/component_build.rs
@@ -22,7 +22,7 @@ pub struct BuildConfig {
 
     /// Expected path to the built Wasm component artifact
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub artifact_path: Option<PathBuf>,
+    pub component_path: Option<PathBuf>,
 }
 
 /// Types of projects that can be built

--- a/plugins/inspect/README.md
+++ b/plugins/inspect/README.md
@@ -50,7 +50,7 @@ wash plugin-inspect /path/to/component.wasm
 
 The plugin automatically registers an `after-dev` hook that will run when `wash dev` sessions end. It will:
 
-1. Look for the component artifact path in the development context
+1. Look for the component component path in the development context
 2. Inspect the component and display its interface information
 3. Provide a summary of the component's exports, imports, and capabilities
 

--- a/plugins/inspect/src/plugin.rs
+++ b/plugins/inspect/src/plugin.rs
@@ -52,9 +52,9 @@ fn is_project_directory(path: &str) -> anyhow::Result<bool> {
     Ok(false)
 }
 
-/// Find common component artifact paths relative to a project directory
+/// Find common component component paths relative to a project directory
 fn find_component_artifact(project_path: &str) -> anyhow::Result<Option<String>> {
-    let common_artifact_paths = [
+    let common_component_paths = [
         "target/wasm32-wasip2/release/component.wasm",
         "target/wasm32-wasip2/debug/component.wasm",
         "build/component.wasm",
@@ -63,11 +63,11 @@ fn find_component_artifact(project_path: &str) -> anyhow::Result<Option<String>>
         "component.wasm",
     ];
 
-    for artifact_path in &common_artifact_paths {
+    for component_path in &common_component_paths {
         let full_path = if project_path == "." {
-            artifact_path.to_string()
+            component_path.to_string()
         } else {
-            format!("{}/{}", project_path, artifact_path)
+            format!("{}/{}", project_path, component_path)
         };
 
         if file_exists(&full_path).unwrap_or(false) {
@@ -78,7 +78,7 @@ fn find_component_artifact(project_path: &str) -> anyhow::Result<Option<String>>
     Ok(None)
 }
 
-/// Request that wash build the project and return the artifact path
+/// Request that wash build the project and return the component path
 fn request_project_build(runner: &Runner, project_path: &str) -> Result<String, String> {
     println!("Building project at: {}", project_path);
 
@@ -87,7 +87,7 @@ fn request_project_build(runner: &Runner, project_path: &str) -> Result<String, 
         Ok((stdout, stderr)) => {
             // Try to find the built artifact
             match find_component_artifact(project_path) {
-                Ok(Some(artifact_path)) => Ok(artifact_path),
+                Ok(Some(component_path)) => Ok(component_path),
                 Ok(None) => Err(format!(
                     "Build completed but no component artifact found in project: {}",
                     project_path
@@ -177,9 +177,9 @@ impl crate::bindings::exports::wasmcloud::wash::plugin::Guest for crate::Compone
 
                             // Try to find existing artifact first
                             match find_component_artifact(&component_path) {
-                                Ok(Some(artifact_path)) => {
-                                    println!("Found existing artifact: {}", artifact_path);
-                                    artifact_path
+                                Ok(Some(component_path)) => {
+                                    println!("Found existing artifact: {}", component_path);
+                                    component_path
                                 }
                                 Ok(None) => {
                                     // No existing artifact - build the project
@@ -265,8 +265,8 @@ impl crate::bindings::exports::wasmcloud::wash::plugin::Guest for crate::Compone
                     "Executing AfterDev hook - inspecting component after development session"
                 );
 
-                // TODO: Get the artifact path from the context
-                // The development session should have set the artifact path in the context
+                // TODO: Get the component path from the context
+                // The development session should have set the component path in the context
                 let context = runner
                     .context()
                     .map_err(|e| format!("Failed to get runner context: {}", e))?;

--- a/plugins/oauth/.wash/config.json
+++ b/plugins/oauth/.wash/config.json
@@ -7,7 +7,7 @@
       "scheduler": "asyncify",
       "wit_world": "oauth"
     },
-    "artifact_path": "build/output.wasm"
+    "component_path": "build/output.wasm"
   },
   "wit": {
     "sources": {

--- a/tests/integration_end_to_end.rs
+++ b/tests/integration_end_to_end.rs
@@ -55,7 +55,7 @@ async fn test_end_to_end_template_to_execution() -> Result<()> {
 
     let cfg = Config {
         build: Some(BuildConfig {
-            artifact_path: Some(
+            component_path: Some(
                 temp_dir
                     .path()
                     .join("dist")
@@ -78,12 +78,12 @@ async fn test_end_to_end_template_to_execution() -> Result<()> {
 
     eprintln!(
         "✅ Built component at: {}",
-        built_component.artifact_path.display()
+        built_component.component_path.display()
     );
 
     // Step 4: Load and execute the component using prepare_component_dev
     let response_body = execute_component_http_handler(
-        &built_component.artifact_path,
+        &built_component.component_path,
         "http://localhost:8080/",
         200,
     )


### PR DESCRIPTION
Renames `artifact_path` to a more descriptive name, `component_path`.

We always expect a `.wasm`, the name `artifact_path` feels like it implies
it could be a different output format like a OCI tarball.

Signed-off-by: Bailey Hayes <behayes2@gmail.com>
