### PR TITLE
ci: fix linking error with auditable

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -105,27 +105,27 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-musl
-            buildCommand: cargo auditable zigbuild
+            buildCommand: cargo zigbuild
             artifact: wash-x86_64-unknown-linux-musl
             runner: ubuntu-latest
             bin: wash
           - target: aarch64-unknown-linux-musl
-            buildCommand: cargo auditable zigbuild
+            buildCommand: cargo zigbuild
             artifact: wash-aarch64-unknown-linux-musl
             runner: ubuntu-latest
             bin: wash
           - target: x86_64-apple-darwin
-            buildCommand: cargo auditable build
+            buildCommand: cargo build
             artifact: wash-x86_64-apple-darwin
             runner: macos-latest
             bin: wash
           - target: aarch64-apple-darwin
-            buildCommand: cargo auditable build
+            buildCommand: cargo build
             artifact: wash-aarch64-apple-darwin
             runner: macos-latest
             bin: wash
           - target: x86_64-pc-windows-msvc
-            buildCommand: cargo auditable build
+            buildCommand: cargo build
             artifact: wash-x86_64-pc-windows-msvc
             runner: windows-latest
             bin: wash.exe
@@ -143,14 +143,8 @@ jobs:
           install-zigbuild: ${{ matrix.runner == 'ubuntu-latest' }}
           rust-targets: "${{ matrix.target }}"
 
-      - name: Install cargo-auditable
-        uses: taiki-e/install-action@71d339ebf191fcbc3d49cd04b9484a4261f29975 # v2.62.9
-        with:
-          tool: cargo-auditable
-
       - name: Build binary (${{ matrix.target }})
         run: |
-          # Build with embedded dependency information for SBOM generation
           ${{ matrix.buildCommand }} --release --target ${{ matrix.target }}
           cp target/${{ matrix.target }}/release/${{ matrix.bin }} ${{ matrix.artifact }}
 
@@ -177,29 +171,10 @@ jobs:
         with:
           path: ./artifacts
 
-      - name: Generate SBOMs
-        run: |
-          # Generate SBOMs from auditable binaries
-          mkdir -p ./sboms
-          for binary in $(find ./artifacts -name 'wash*' -type f); do
-            binary_name=$(basename "$binary")
-            cargo auditable --version > /dev/null 2>&1 || cargo install cargo-auditable
-            # Extract SBOM from the auditable binary
-            if command -v cargo-auditable &> /dev/null; then
-              cargo auditable extract-audit "$binary" --format json > "./sboms/${binary_name}.sbom.cdx.json" || echo "SBOM extraction failed for $binary"
-            fi
-          done
-
       - name: Generate build provenance attestations
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: "./artifacts/*/wash*"
-
-      - name: Generate SBOM attestations
-        uses: actions/attest-sbom@v1
-        with:
-          subject-path: "./artifacts/*/wash*"
-          sbom-path: "./sboms/*.sbom.cdx.json"
 
       - name: Create GitHub Release and upload binaries
         uses: softprops/action-gh-release@v2
@@ -208,7 +183,6 @@ jobs:
           tag_name: ${{ github.ref_name }}
           files: |
             ./artifacts/*/*
-            sboms/*.sbom.cdx.json
           token: ${{ github.token }}
           prerelease: false
           generate_release_notes: true

--- a/install.sh
+++ b/install.sh
@@ -328,14 +328,6 @@ verify_artifact_signature() {
         return 1
     fi
 
-    # Verify SBOM attestation
-    if ! gh attestation verify "$artifact_path" \
-        --repo "$REPO" \
-        --predicate-type https://spdx.dev/Document; then
-        log_error "SBOM attestation verification failed!"
-        return 1
-    fi
-
     log_success "Artifact attestations verified successfully!"
 }
 


### PR DESCRIPTION
It seems cargo auditable is incompatible with our zig build.

Yanking sbom generation for now.

Signed-off-by: Bailey Hayes <behayes2@gmail.com>

## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
