### PR TITLE
Add OCI annotations based on metadata attached to wasm payload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,12 +62,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +358,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "auditable-serde"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7bf8143dfc3c0258df908843e169b5cc5fcf76c7718bd66135ef4a9cd558c5"
+dependencies = [
+ "semver",
+ "serde",
+ "serde_json",
+ "topological-sort",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,17 +629,16 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5008,6 +5013,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "topological-sort"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
+
+[[package]]
 name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5492,6 +5503,7 @@ dependencies = [
  "atty",
  "base64 0.22.1",
  "bytes",
+ "chrono",
  "clap",
  "clap-markdown",
  "clap_complete",
@@ -5524,6 +5536,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "wasm-metadata 0.239.0",
  "wasm-pkg-client",
  "wasm-pkg-core",
  "wasmcloud-runtime",
@@ -5717,6 +5730,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be00faa2b4950c76fe618c409d2c3ea5a3c9422013e079482d78544bb2d184c"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.239.0",
+]
+
+[[package]]
 name = "wasm-gen"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5765,6 +5788,25 @@ dependencies = [
  "indexmap 2.9.0",
  "wasm-encoder 0.235.0",
  "wasmparser 0.235.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20b3ec880a9ac69ccd92fbdbcf46ee833071cf09f82bb005b2327c7ae6025ae2"
+dependencies = [
+ "anyhow",
+ "auditable-serde",
+ "flate2",
+ "indexmap 2.9.0",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "spdx",
+ "url",
+ "wasm-encoder 0.239.0",
+ "wasmparser 0.239.0",
 ]
 
 [[package]]
@@ -6016,6 +6058,18 @@ name = "wasmparser"
 version = "0.235.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
+dependencies = [
+ "bitflags 2.9.1",
+ "hashbrown 0.15.4",
+ "indexmap 2.9.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
 dependencies = [
  "bitflags 2.9.1",
  "hashbrown 0.15.4",
@@ -6475,7 +6529,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -6509,12 +6563,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-registry"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -6525,7 +6585,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6534,7 +6594,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6610,7 +6670,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ clap = { version = "4.5.40", default-features = false, features = ["derive", "en
 clap_complete = { version = "4.5.40", default-features = false }
 clap-markdown = { version = "0.1.5", default-features = false }
 ctrlc = { version = "3.4.7", default-features = false }
+chrono = { version = "0.4.42", default-features = false, features = ["alloc"] }
 dialoguer = { version = "0.11.0", default-features = false, features = ["editor", "password", "zeroize", "fuzzy-select", "fuzzy-matcher"] }
 docker_credential = { version = "1.3.1", default-features = false }
 etcetera = { version = "0.10.0", default-features = false }
@@ -59,6 +60,7 @@ url = { version = "2.5", default-features = false }
 uuid = { version = "1.17.0", default-features = false, features = ["std"] }
 wasm-pkg-client = { version = "0.10.0", default-features = false }
 wasm-pkg-core = { version = "0.10.0", default-features = false }
+wasm-metadata = { version = "0.239.0", default-features = false, features = ["oci"] }
 wasmcloud-runtime = { git = "https://github.com/wasmCloud/wasmCloud", version = "0.11.0" }
 wasmtime = { version = "31", default-features = false }
 wasmtime-wasi = { version = "31", default-features = false }

--- a/crates/wash/src/cli/oci.rs
+++ b/crates/wash/src/cli/oci.rs
@@ -1,9 +1,12 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use anyhow::Context as _;
+use chrono::Local;
 use clap::{Args, Subcommand};
 use etcetera::AppStrategy;
 use tracing::instrument;
+use wasm_metadata::Payload;
 
 use crate::{
     cli::{CliCommand, CliContext, CommandOutput},
@@ -96,9 +99,64 @@ impl PushCommand {
             .await
             .context("failed to read component file")?;
 
+        let payload = Payload::from_binary(&component)?;
+        let metadata = payload.metadata();
+
+        let mut all_annotations = HashMap::new();
+        if let Some(name) = &metadata.name {
+            all_annotations.insert("org.opencontainers.image.title".into(), name.to_string());
+        }
+        if let Some(description) = &metadata.description {
+            all_annotations.insert(
+                "org.opencontainers.image.description".into(),
+                description.to_string(),
+            );
+        }
+        if let Some(authors) = &metadata.authors {
+            all_annotations.insert(
+                "org.opencontainers.image.authors".into(),
+                authors.to_string(),
+            );
+        }
+        if let Some(source) = &metadata.source {
+            all_annotations.insert("org.opencontainers.image.source".into(), source.to_string());
+        }
+        if let Some(homepage) = &metadata.homepage {
+            all_annotations.insert("org.opencontainers.image.url".into(), homepage.to_string());
+        }
+        if let Some(version) = &metadata.version {
+            all_annotations.insert(
+                "org.opencontainers.image.version".into(),
+                version.to_string(),
+            );
+        }
+        if let Some(revision) = &metadata.revision {
+            all_annotations.insert(
+                "org.opencontainers.image.revision".into(),
+                revision.to_string(),
+            );
+        }
+        if let Some(licenses) = &metadata.licenses {
+            all_annotations.insert(
+                "org.opencontainers.image.licenses".into(),
+                licenses.to_string(),
+            );
+        }
+
+        all_annotations.insert(
+            "org.opencontainers.image.created".into(),
+            Local::now().to_rfc3339(),
+        );
+
         let oci_config = OciConfig::new_with_cache(ctx.cache_dir().join(OCI_CACHE_DIR));
 
-        let digest = push_component(&self.reference, &component, oci_config).await?;
+        let digest = push_component(
+            &self.reference,
+            &component,
+            oci_config,
+            Some(all_annotations),
+        )
+        .await?;
 
         Ok(CommandOutput::ok(
             "OCI command executed successfully.".to_string(),


### PR DESCRIPTION
When pushing an OCI artifact, attach metadata such as source, url, description, version, and licenses to the container image based on the metadata attached to the wasm payload that was constructed in the build step.

## Feature or Problem

See #78 

## Related Issues

#78

## Release Information

Next.

## Consumer Impact

OCI artifacts now contain metadata when pushed to a registry.

## Testing

### Unit Test(s)

TODO

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
