### PR TITLE
Perform an uninstall first when installing plugins with --force flag

### DIFF
--- a/crates/wash/src/plugin.rs
+++ b/crates/wash/src/plugin.rs
@@ -345,11 +345,16 @@ pub async fn install_plugin(
     let plugin_path = plugins_dir.join(format!("{sanitized_name}.wasm"));
 
     // Check if plugin already exists
-    if plugin_path.exists() && !options.force {
-        bail!(
-            "Plugin '{}' already exists. Use --force option to overwrite",
-            metadata.name
-        );
+    if plugin_path.exists() {
+        if options.force {
+            // uninstall first, to really force clean re-install
+            uninstall_plugin(ctx, &metadata.name).await?;
+        } else {
+            bail!(
+                "Plugin '{}' already exists. Use --force option to overwrite",
+                metadata.name
+            );
+        }
     }
     // Write plugin to storage
     tokio::fs::write(&plugin_path, &component_data)


### PR DESCRIPTION
## Feature or Problem

Plugins that are "re-installed" with a `--force` flag do not seem to replace existing plugins.

## Related Issues

wasmCloud/wasmCloud#4956 

## Release Information

Next

## Consumer Impact


## Testing


### Unit Test(s)


### Acceptance or Integration


### Manual Verification

@ricochet I wanted to test this using the sample plugin from the wasmCloud repository (https://github.com/wasmCloud/wasmCloud/tree/main/examples/rust/components/wash-plugin-rust). However, while the plugin builds, I cannot even install it due to a failure to get host bindings (`failed to create plugin host bindings`) https://github.com/wasmCloud/wash/blob/9ccd417fe9af34b6f1a2892610b466cef67c9f0c/crates/wash/src/plugin.rs#L68

Is the sample plugin outdated?
