### PR TITLE
Pass additional arguments to build commands

### DIFF
--- a/crates/wash/src/cli/component_build.rs
+++ b/crates/wash/src/cli/component_build.rs
@@ -42,7 +42,9 @@ pub struct ComponentBuildCommand {
     #[clap(long = "skip-fetch")]
     skip_fetch: bool,
 
-    /// The arguments to pass to the build command
+    /// Additional arguments to pass to the underlying build command (cargo, tinygo, or npm/pnpm/yarn).
+    /// These arguments must come after a '--' separator.
+    /// Example: wash build -- --release --features extra
     #[clap(
         name = "arg",
         trailing_var_arg = true,
@@ -986,7 +988,7 @@ impl ComponentBuilder {
                 build_args.push(flag.clone());
             }
 
-            // Add any additional cargo flags provided via CLI
+            // Add any additional build flags provided via CLI
             build_args.extend_from_slice(args.unwrap_or_default());
 
             debug!(package_manager = %package_manager, build_args = ?build_args, "running build command");

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -137,7 +137,7 @@ impl CliCommand for DevCommand {
             debug!("no recommendations found for project tools");
         }
 
-        let component_path = match build_component(&self.project_dir, ctx, &config).await {
+        let component_path = match build_component(&self.project_dir, ctx, &config, None).await {
             // Edge case where the build was successful, but the component path in the config is different
             // than the one returned by the build process.
             Ok(build_result)
@@ -405,6 +405,7 @@ impl CliCommand for DevCommand {
                         &self.project_dir,
                         ctx,
                         &rebuild_config,
+                        None,
                     ).await;
 
                     match rebuild_result {

--- a/crates/wash/src/cli/inspect.rs
+++ b/crates/wash/src/cli/inspect.rs
@@ -66,7 +66,7 @@ impl CliCommand for InspectCommand {
                         .await
                         .context("Failed to load project configuration")?;
 
-                    let build_result = build_component(path, ctx, &config)
+                    let build_result = build_component(path, ctx, &config, None)
                         .await
                         .context("Failed to build component from project directory")?;
 

--- a/crates/wash/src/cli/plugin.rs
+++ b/crates/wash/src/cli/plugin.rs
@@ -328,7 +328,7 @@ impl TestCommand {
                 .ensure_config(Some(self.plugin.as_path()))
                 .await
                 .context("failed to load config")?;
-            let built_path = build_component(&self.plugin, ctx, &config)
+            let built_path = build_component(&self.plugin, ctx, &config, None)
                 .await
                 .context("Failed to build component from directory")?;
             tokio::fs::read(&built_path.component_path)

--- a/tests/integration_end_to_end.rs
+++ b/tests/integration_end_to_end.rs
@@ -73,6 +73,7 @@
 //             .await
 //             .expect("failed to create CLI context"),
 //         &cfg,
+//         Some(&vec!["--release".into()]),
 //     )
 //     .await
 //     .context("failed to build component")?;


### PR DESCRIPTION
Relates-to: 

## Feature or Problem

Allow to pass additional arguments to build systems on the `build` command.

## Related Issues

wasmCloud/wasmCloud#4958

## Release Information

Next

## Consumer Impact

None.

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration

Added a `--release` flag in one of the integration tests.

### Manual Verification

Built a custom component with additional flags:

```console
$ wash build --skip-fetch
2025-10-08T07:18:20.092760Z  INFO building component path="."
2025-10-08T07:18:53.052954Z  INFO cargo build --target wasm32-wasip2 --color always completed in 32.96s
2025-10-08T07:18:53.054584Z  INFO Generated project configuration at ./.wash/config.json
Successfully built component at: <redacted>

$ wash build --skip-fetch . -- --release
2025-10-08T07:19:36.695847Z  INFO building component path="."
2025-10-08T07:19:36.908974Z  INFO cargo build --target wasm32-wasip2 --color always --release completed in 0.21s
Successfully built component at: <redacted>
```

We can see that the `--release` flag was correctly passed to `cargo`.
