### PR TITLE
Use trait in CliContext to avoid conditional compilation

### DIFF
--- a/crates/wash/src/cli/component_build.rs
+++ b/crates/wash/src/cli/component_build.rs
@@ -9,7 +9,6 @@ use std::{
 use anyhow::{Context as _, bail};
 use atty;
 use clap::Args;
-use etcetera::AppStrategy;
 use indicatif::{ProgressBar, ProgressStyle};
 use serde::Serialize;
 use tokio::{fs, process::Command};

--- a/crates/wash/src/cli/config.rs
+++ b/crates/wash/src/cli/config.rs
@@ -1,6 +1,5 @@
 use anyhow::Context as _;
 use clap::Subcommand;
-use etcetera::AppStrategy as _;
 use tracing::instrument;
 
 use crate::{

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -10,7 +10,6 @@ use std::{
 use anyhow::{Context as _, ensure};
 use base64::Engine;
 use clap::Args;
-use etcetera::AppStrategy as _;
 use hyper::server::conn::http1;
 use notify::{
     Event as NotifyEvent, RecursiveMode, Watcher,

--- a/crates/wash/src/cli/doctor.rs
+++ b/crates/wash/src/cli/doctor.rs
@@ -3,7 +3,6 @@
 use crate::cli::{CliCommand, CliContext, CommandOutput};
 use anyhow::{Context as _, bail};
 use clap::Args;
-use etcetera::AppStrategy as _;
 use std::path::{Path, PathBuf};
 use tokio::process::Command;
 use tracing::{debug, instrument, trace};

--- a/crates/wash/src/cli/inspect.rs
+++ b/crates/wash/src/cli/inspect.rs
@@ -1,5 +1,4 @@
 use clap::Args;
-use etcetera::AppStrategy;
 use tracing::{info, instrument};
 
 use crate::{

--- a/crates/wash/src/cli/oci.rs
+++ b/crates/wash/src/cli/oci.rs
@@ -2,7 +2,6 @@ use std::path::PathBuf;
 
 use anyhow::Context as _;
 use clap::{Args, Subcommand};
-use etcetera::AppStrategy;
 use tracing::instrument;
 
 use crate::{

--- a/crates/wash/src/cli/plugin.rs
+++ b/crates/wash/src/cli/plugin.rs
@@ -4,7 +4,6 @@ use std::{path::PathBuf, sync::Arc};
 use anyhow::Context;
 use anyhow::bail;
 use clap::{Args, Subcommand};
-use etcetera::AppStrategy;
 use hyper::server::conn::http1;
 use serde_json::json;
 use tokio::net::TcpListener;

--- a/crates/wash/src/cli/update.rs
+++ b/crates/wash/src/cli/update.rs
@@ -2,7 +2,6 @@
 
 use anyhow::Context as _;
 use clap::Args;
-use etcetera::AppStrategy as _;
 use reqwest::{
     Client,
     header::{AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT},
@@ -215,7 +214,7 @@ impl CliCommand for UpdateCommand {
             warn!(
                 "Cannot find installed wash binary, assuming installation in a non-standard location."
             );
-            let install_path = ctx.in_data_dir(format!("{BINARY_NAME}_{os}_{arch}"));
+            let install_path = ctx.in_data_dir(&format!("{BINARY_NAME}_{os}_{arch}"));
             tokio::fs::create_dir_all(ctx.data_dir())
                 .await
                 .context("failed to create data directory")?;

--- a/crates/wash/src/new.rs
+++ b/crates/wash/src/new.rs
@@ -3,7 +3,6 @@
 use std::path::Path;
 
 use anyhow::{Context as _, bail};
-use etcetera::AppStrategy as _;
 use serde::{Deserialize, Serialize};
 use tokio::process::Command;
 use tracing::{debug, error, info, instrument};

--- a/crates/wash/src/plugin.rs
+++ b/crates/wash/src/plugin.rs
@@ -4,7 +4,6 @@
 //! Plugins are WebAssembly components that extend wash functionality.
 
 use anyhow::{Context as _, bail};
-use etcetera::AppStrategy;
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},


### PR DESCRIPTION
## Feature or Problem

Avoid conditionally compiling based on target OS to get AppStrategy. Instead use wrapper trait to provide same functionality in a way that makes it simpler to test and extend strategy capabilities.

## Related Issues

#25

## Release Information

Next.

## Consumer Impact

None.

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
