### PR TITLE
feat(build): support additional build toolchain args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5969,9 +5969,9 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]

--- a/crates/wash/src/cli/component_build.rs
+++ b/crates/wash/src/cli/component_build.rs
@@ -41,6 +41,10 @@ pub struct ComponentBuildCommand {
     /// Skip fetching WIT dependencies, useful for offline builds
     #[clap(long = "skip-fetch")]
     skip_fetch: bool,
+
+    /// The arguments to pass to the native build tool (cargo, tinygo, npm, etc.)
+    #[clap(name = "arg", trailing_var_arg = true, allow_hyphen_values = true)]
+    pub args: Vec<String>,
 }
 
 impl CliCommand for ComponentBuildCommand {
@@ -56,6 +60,16 @@ impl CliCommand for ComponentBuildCommand {
                 skip_fetch: self.skip_fetch,
                 ..Default::default()
             })
+        }
+        if let Some(build) = config.build.as_mut() {
+            if !self.args.is_empty() {
+                build.additional_args = self.args.clone();
+            }
+        } else {
+            config.build = Some(crate::component_build::BuildConfig {
+                additional_args: self.args.clone(),
+                ..Default::default()
+            });
         }
         let result = build_component(&self.project_path, ctx, &config).await?;
 
@@ -542,8 +556,15 @@ impl ComponentBuilder {
         // Build cargo command arguments
         let mut cargo_args = vec!["build".to_string()];
 
+        let release_mode = rust_config.release
+            || config
+                .build
+                .as_ref()
+                .map(|b| b.additional_args.contains(&"--release".to_string()))
+                .unwrap_or(false);
+
         // Apply release mode if configured
-        if rust_config.release {
+        if release_mode {
             cargo_args.push("--release".to_string());
         }
 
@@ -574,6 +595,14 @@ impl ComponentBuilder {
         // Add any additional cargo flags if configured
         for flag in &rust_config.cargo_flags {
             cargo_args.push(flag.clone());
+        }
+
+        if let Some(build_config) = &config.build {
+            for arg in &build_config.additional_args {
+                if arg != "--release" {
+                    cargo_args.push(arg.clone());
+                }
+            }
         }
 
         debug!(cargo_args = ?cargo_args, "running cargo with args");
@@ -619,11 +648,7 @@ impl ComponentBuilder {
         }
 
         // Find the generated wasm file
-        let build_type = if rust_config.release {
-            "release"
-        } else {
-            "debug"
-        };
+        let build_type = if release_mode { "release" } else { "debug" };
         let target_dir = self
             .project_path
             .join(format!("target/{}/{}", rust_config.target, build_type));
@@ -791,6 +816,12 @@ impl ComponentBuilder {
             tinygo_args.push(flag.to_string());
         }
 
+        if let Some(build_config) = &config.build {
+            for arg in &build_config.additional_args {
+                tinygo_args.push(arg.clone());
+            }
+        }
+
         // Add source directory
         tinygo_args.push(".".to_string());
 
@@ -956,6 +987,12 @@ impl ComponentBuilder {
             // Add any additional build flags if configured
             for flag in &ts_config.build_flags {
                 build_args.push(flag.clone());
+            }
+
+            if let Some(build_config) = &config.build {
+                for arg in &build_config.additional_args {
+                    build_args.push(arg.clone());
+                }
             }
 
             debug!(package_manager = %package_manager, build_args = ?build_args, "running build command");

--- a/crates/wash/src/cli/plugin.rs
+++ b/crates/wash/src/cli/plugin.rs
@@ -383,7 +383,7 @@ impl TestCommand {
                     ) =>
                 {
                     let _ = e.print();
-                    return Ok(CommandOutput::error("", None));
+                    return Ok(CommandOutput::error(e.to_string(), None));
                 }
                 Err(e) => anyhow::bail!("Failed to parse command arguments: {}", e),
             };

--- a/crates/wash/src/cli/plugin.rs
+++ b/crates/wash/src/cli/plugin.rs
@@ -196,7 +196,7 @@ pub struct TestCommand {
         name = "arg",
         conflicts_with = "type",
         trailing_var_arg = true,
-        // TODO: --help won't get collected into this args
+        allow_hyphen_values = true
     )]
     pub args: Vec<String>,
 }
@@ -383,7 +383,7 @@ impl TestCommand {
                     ) =>
                 {
                     let _ = e.print();
-                    return Ok(CommandOutput::error(e.to_string(), None));
+                    return Ok(CommandOutput::error("", None));
                 }
                 Err(e) => anyhow::bail!("Failed to parse command arguments: {}", e),
             };
@@ -394,7 +394,7 @@ impl TestCommand {
                 plugin_component: Some(plugin),
             };
 
-            output.push_str(component_plugin_command.handle(ctx).await?.message.as_str());
+            output = component_plugin_command.handle(ctx).await?.message;
         }
 
         Ok(CommandOutput::ok(

--- a/crates/wash/src/component_build.rs
+++ b/crates/wash/src/component_build.rs
@@ -24,6 +24,7 @@ pub struct BuildConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub component_path: Option<PathBuf>,
 
+    /// Additional arguments to pass to the build toolchain (cargo, tinygo, npm)
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub additional_args: Vec<String>,
 }

--- a/crates/wash/src/component_build.rs
+++ b/crates/wash/src/component_build.rs
@@ -23,6 +23,9 @@ pub struct BuildConfig {
     /// Expected path to the built Wasm component artifact
     #[serde(skip_serializing_if = "Option::is_none")]
     pub component_path: Option<PathBuf>,
+
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub additional_args: Vec<String>,
 }
 
 /// Types of projects that can be built


### PR DESCRIPTION
## Feature or Problem
This PR adds the ability to parse any unknown trailing arguments to `wash build` directly to the underlying build toolchain.

For example, when running `wash build` on a Rust project, you can simply `wash build --release` to build the component in release mode.

Because of this, I'm strongly leaning towards removing all of the specialized build arguments in the `.wash/config.json`, because it's so much more flexible to be able to specify these with the native toolchain. @ricochet thoughts?

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
next

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
