### PR TITLE
feat: Docker Canary Image

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -69,8 +69,10 @@ jobs:
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ricochet
+          password: ${{ secrets.WASMCLOUD_PACKAGES_PAT }}
+          # username: ${{ github.actor }}
+          # password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Meta
         id: meta
@@ -137,8 +139,10 @@ jobs:
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ricochet
+          password: ${{ secrets.WASMCLOUD_PACKAGES_PAT }}
+          # username: ${{ github.actor }}
+          # password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -58,7 +58,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     permissions:
-      id-token: write
       contents: write
       packages: write
     outputs:
@@ -121,7 +120,6 @@ jobs:
     if: ${{ inputs.push }}
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: write
       packages: write
     needs:

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -51,10 +51,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - arch: arm64
-            runner: ubuntu-latest-arm
           - arch: amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,164 @@
+name: docker-build-push
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        type: string
+        required: false
+        default: "."
+      file:
+        type: string
+        required: false
+        description: "Dockerfile to use for the build. Defaults to Dockerfile in the working directory"
+        default: "./Dockerfile"
+      image:
+        type: string
+        required: true
+        description: "Image to use for the build WITHOUT the tag"
+      tags:
+        type: string
+        required: true
+        description: "Tags to use for the image. Follows the format of docker/metadata-action@v5"
+      build-args:
+        type: string
+        required: false
+        description: "Build arguments to pass to docker build"
+        default: ""
+      push:
+        type: boolean
+        description: "Build and Push Image. Default=false"
+        required: false
+        default: false
+      build-contexts:
+        type: string
+        required: false
+        description: "Additional build contexts"
+      build-cache:
+        type: boolean
+        required: false
+        description: "Enables Github Actions Image cache. Default=true"
+        default: true
+    outputs:
+      image_digest:
+        description: "Image digest of the container that was built"
+        value: ${{ jobs.build.outputs.image_digest }}
+      artifact_prefix:
+        description: "Image digest of the container that was built without the sha256: prefix"
+        value: ${{ jobs.build.outputs.artifact_prefix }}
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - arch: arm64
+            runner: ubuntu-latest-arm
+          - arch: amd64
+            runner: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: write
+      packages: write
+    outputs:
+      image_digest: ${{ steps.build.outputs.digest }}
+      artifact_prefix: ${{ steps.meta.outputs.artifact_prefix }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Login to ghcr.io
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Meta
+        id: meta
+        run: |
+          # Create a prefix for the artifact name by taking the image name, removing any registry and replacing / and : with _
+          ARTIFACT_PREFIX=$(echo "${{ inputs.image }}" | sed 's/.*\///; s/[\/:]/_/g')
+          echo "artifact_prefix=${ARTIFACT_PREFIX}" >> "${GITHUB_OUTPUT}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          file: ${{ inputs.file }}
+          context: ${{ inputs.working-directory }}
+          tags: ${{ inputs.image }}
+          build-contexts: ${{ inputs.build-contexts }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          build-args: ${{ inputs.build-args }}
+          cache-from: |
+            type=gha,scope=buildx-${{ steps.meta.outputs.artifact_prefix }}-${{ matrix.arch }}-${{ github.ref_name }}
+            type=gha,scope=buildx-${{ steps.meta.outputs.artifact_prefix }}-${{ matrix.arch }}-main
+          cache-to: |
+            type=gha,scope=buildx-${{ steps.meta.outputs.artifact_prefix }}-${{ matrix.arch }}-${{ github.ref_name }},mode=max
+
+      - name: Export digest
+        id: export
+        run: | #shell
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: digests-${{ steps.meta.outputs.artifact_prefix }}-${{ github.run_id }}-linux-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    if: ${{ inputs.push }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      packages: write
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Download digests
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-${{ needs.build.outputs.artifact_prefix }}-${{ github.run_id }}-*
+          merge-multiple: true
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ inputs.image }}
+          tags: ${{ inputs.tags }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          # shellcheck disable=SC2046
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ inputs.image }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ inputs.image }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -104,7 +104,9 @@ jobs:
           cargo machete
 
   canary:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # PR 125
+    if: github.event.number == 125
     uses: ./.github/workflows/docker-build-push.yml
     secrets: inherit
     with:

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -104,9 +104,7 @@ jobs:
           cargo machete
 
   canary:
-    # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    # PR 125
-    if: github.event.number == 125
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -111,7 +111,7 @@ jobs:
     secrets: inherit
     with:
       push: true
-      image: ghcr.io/wasmCloud/wash
+      image: ghcr.io/wasmcloud/wash
       tags: |
         type=raw,value=canary-v2
 

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -103,6 +103,16 @@ jobs:
         run: |
           cargo machete
 
+  canary:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/docker-build-push.yml
+    secrets: inherit
+    with:
+      push: true
+      image: ghcr.io/wasmCloud/wash
+      tags: |
+        type=raw,value=canary
+
   release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/wash-v')
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -107,6 +107,9 @@ jobs:
     # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     # PR 125
     if: github.event.number == 125
+    permissions:
+      contents: write
+      packages: write
     uses: ./.github/workflows/docker-build-push.yml
     secrets: inherit
     with:

--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -111,7 +111,7 @@ jobs:
       push: true
       image: ghcr.io/wasmCloud/wash
       tags: |
-        type=raw,value=canary
+        type=raw,value=canary-v2
 
   release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/wash-v')


### PR DESCRIPTION
Builds & Pushes a docker image to `ghcr.io/wasmCloud/wash:canary-v2` on `main` merges.

Note the image above is also being used in the main wasmcloud repo https://github.com/wasmCloud/wasmCloud/pkgs/container/wash

will need a few iterations to get it right so will run it on this branch