### PR TITLE
refactor: rename RuntimeConfig to WasiConfig

### DIFF
--- a/crates/wash-runtime/README.md
+++ b/crates/wash-runtime/README.md
@@ -25,7 +25,7 @@ use wash_runtime::{
     engine::Engine,
     host::{HostBuilder, HostApi},
     plugin::{
-        wasi_config::RuntimeConfig,
+        wasi_config::WasiConfig,
         wasi_http::HttpServer,
     },
     types::{WorkloadStartRequest, Workload},
@@ -38,13 +38,13 @@ async fn main() -> anyhow::Result<()> {
 
     // Configure plugins
     let http_plugin = HttpServer::new("127.0.0.1:8080".parse()?);
-    let runtime_config_plugin = RuntimeConfig::default();
+    let wasi_config_plugin = WasiConfig::default();
 
     // Build and start the host
     let host = HostBuilder::new()
         .with_engine(engine)
         .with_plugin(Arc::new(http_plugin))?
-        .with_plugin(Arc::new(runtime_config_plugin))?
+        .with_plugin(Arc::new(wasi_config_plugin))?
         .build()?;
 
     let host = host.start().await?;

--- a/crates/wash-runtime/src/lib.rs
+++ b/crates/wash-runtime/src/lib.rs
@@ -20,7 +20,7 @@ mod test {
     use std::collections::HashMap;
     use std::sync::Arc;
 
-    use crate::plugin::wasi_config::RuntimeConfig;
+    use crate::plugin::wasi_config::WasiConfig;
     use crate::plugin::wasi_http::HttpServer;
     use crate::{
         host::HostApi,
@@ -34,12 +34,12 @@ mod test {
     async fn can_run_engine() -> anyhow::Result<()> {
         let engine = Engine::builder().build()?;
         let http_plugin = HttpServer::new("127.0.0.1:8080".parse()?);
-        let runtime_config_plugin = RuntimeConfig::default();
+        let wasi_config_plugin = WasiConfig::default();
 
         let host = HostBuilder::new()
             .with_engine(engine)
             .with_plugin(Arc::new(http_plugin))?
-            .with_plugin(Arc::new(runtime_config_plugin))?
+            .with_plugin(Arc::new(wasi_config_plugin))?
             .build()?;
 
         let host = host.start().await?;

--- a/crates/wash-runtime/src/plugin/mod.rs
+++ b/crates/wash-runtime/src/plugin/mod.rs
@@ -16,7 +16,7 @@
 //!
 //! The crate provides several built-in plugins for common WASI interfaces:
 //! - [`wasi_http`] - HTTP server capabilities (`wasi:http/incoming-handler`)
-//! - [`wasi_config`] - Runtime configuration (`wasi:config/runtime`)
+//! - [`wasi_config`] - Runtime configuration (`wasi:config/store`)
 //! - [`wasi_blobstore`] - Object storage (`wasi:blobstore`)
 //! - [`wasi_keyvalue`] - Key-value storage (`wasi:keyvalue`)
 //! - [`wasi_logging`] - Structured logging (`wasi:logging`)

--- a/crates/wash-runtime/src/plugin/wasi_config.rs
+++ b/crates/wash-runtime/src/plugin/wasi_config.rs
@@ -39,17 +39,17 @@ mod bindings {
 
 use bindings::wasi::config::store::Host;
 
-const RUNTIME_CONFIG_ID: &str = "runtime-config";
+const WASI_CONFIG_ID: &str = "wasi-config";
 
 type ConfigMap = HashMap<Arc<str>, HashMap<String, String>>;
 
-/// Runtime configuration plugin that provides access to configuration data.
+/// WASI configuration plugin that provides access to configuration data.
 ///
 /// This plugin implements the WASI config interface, allowing components to
 /// retrieve configuration values and environment variables at runtime. Each
 /// component gets isolated access to its own configuration scope.
 #[derive(Clone, Default)]
-pub struct RuntimeConfig {
+pub struct WasiConfig {
     /// A map of configuration from component id to key-value pairs
     config: Arc<RwLock<ConfigMap>>,
 }
@@ -59,7 +59,7 @@ impl Host for Ctx {
         &mut self,
         key: String,
     ) -> anyhow::Result<Result<Option<String>, bindings::wasi::config::store::Error>> {
-        let Some(plugin) = self.get_plugin::<RuntimeConfig>(RUNTIME_CONFIG_ID) else {
+        let Some(plugin) = self.get_plugin::<WasiConfig>(WASI_CONFIG_ID) else {
             return Ok(Ok(None));
         };
         let config_guard = plugin.config.read().await;
@@ -72,7 +72,7 @@ impl Host for Ctx {
     async fn get_all(
         &mut self,
     ) -> anyhow::Result<Result<Vec<(String, String)>, bindings::wasi::config::store::Error>> {
-        let Some(plugin) = self.get_plugin::<RuntimeConfig>(RUNTIME_CONFIG_ID) else {
+        let Some(plugin) = self.get_plugin::<WasiConfig>(WASI_CONFIG_ID) else {
             return Ok(Ok(vec![]));
         };
         let config_guard = plugin.config.read().await;
@@ -85,9 +85,9 @@ impl Host for Ctx {
 }
 
 #[async_trait::async_trait]
-impl HostPlugin for RuntimeConfig {
+impl HostPlugin for WasiConfig {
     fn id(&self) -> &'static str {
-        RUNTIME_CONFIG_ID
+        WASI_CONFIG_ID
     }
 
     fn world(&self) -> WitWorld {
@@ -107,7 +107,7 @@ impl HostPlugin for RuntimeConfig {
         }) else {
             // Log a warning if the requested interfaces are not wasi:config/store
             tracing::warn!(
-                "RuntimeConfig plugin requested for non-wasi:config/store interface(s): {:?}",
+                "WasiConfig plugin requested for non-wasi:config/store interface(s): {:?}",
                 interfaces
             );
             return Ok(());

--- a/crates/wash-runtime/tests/integration_http_counter.rs
+++ b/crates/wash-runtime/tests/integration_http_counter.rs
@@ -19,7 +19,7 @@ use wash_runtime::{
     engine::Engine,
     host::{HostApi, HostBuilder},
     plugin::{
-        wasi_blobstore::WasiBlobstore, wasi_config::RuntimeConfig, wasi_http::HttpServer,
+        wasi_blobstore::WasiBlobstore, wasi_config::WasiConfig, wasi_http::HttpServer,
         wasi_keyvalue::WasiKeyvalue, wasi_logging::WasiLogging,
     },
     types::{Component, LocalResources, Workload, WorkloadStartRequest},
@@ -54,7 +54,7 @@ async fn test_http_counter_integration() -> Result<()> {
     let logging_plugin = WasiLogging {};
 
     // Create config plugin
-    let config_plugin = RuntimeConfig::default();
+    let config_plugin = WasiConfig::default();
 
     // Build host with all required plugins
     let host = HostBuilder::new()
@@ -393,7 +393,7 @@ async fn test_http_counter_error_scenarios() -> Result<()> {
     let blobstore_plugin = WasiBlobstore::new(None);
     let keyvalue_plugin = WasiKeyvalue::new();
     let logging_plugin = WasiLogging {};
-    let config_plugin = RuntimeConfig::default();
+    let config_plugin = WasiConfig::default();
 
     let host = HostBuilder::new()
         .with_engine(engine)

--- a/crates/wash-runtime/tests/integration_http_keyvalue.rs
+++ b/crates/wash-runtime/tests/integration_http_keyvalue.rs
@@ -18,7 +18,7 @@ use wash_runtime::{
     engine::Engine,
     host::{HostApi, HostBuilder},
     plugin::{
-        wasi_blobstore::WasiBlobstore, wasi_config::RuntimeConfig, wasi_http::HttpServer,
+        wasi_blobstore::WasiBlobstore, wasi_config::WasiConfig, wasi_http::HttpServer,
         wasi_keyvalue::WasiKeyvalue, wasi_logging::WasiLogging,
     },
     types::{Component, LocalResources, Workload, WorkloadStartRequest},
@@ -50,7 +50,7 @@ async fn test_http_keyvalue_counter_integration() -> Result<()> {
     let blobstore_plugin = WasiBlobstore::new(None);
 
     // Create config plugin
-    let config_plugin = RuntimeConfig::default();
+    let config_plugin = WasiConfig::default();
 
     // Create logging plugin
     let logging_plugin = WasiLogging {};
@@ -322,7 +322,7 @@ async fn test_keyvalue_counter_concurrent_access() -> Result<()> {
     let http_plugin = HttpServer::new(addr);
     let keyvalue_plugin = WasiKeyvalue::new();
     let blobstore_plugin = WasiBlobstore::new(None);
-    let config_plugin = RuntimeConfig::default();
+    let config_plugin = WasiConfig::default();
     let logging_plugin = WasiLogging {};
 
     let host = HostBuilder::new()
@@ -502,7 +502,7 @@ async fn test_keyvalue_error_handling() -> Result<()> {
     let http_plugin = HttpServer::new(addr);
     let keyvalue_plugin = WasiKeyvalue::new();
     let blobstore_plugin = WasiBlobstore::new(None);
-    let config_plugin = RuntimeConfig::default();
+    let config_plugin = WasiConfig::default();
     let logging_plugin = WasiLogging {};
 
     let host = HostBuilder::new()

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -46,7 +46,7 @@ impl CliCommand for HostCommand {
             .with_nats_client(Arc::new(scheduler_nats_client))
             .with_host_group(self.host_group.clone())
             .with_plugin(Arc::new(
-                wash_runtime::washlet::plugins::wasi_config::RuntimeConfig::default(),
+                wash_runtime::washlet::plugins::wasi_config::WasiConfig::default(),
             ))?
             .with_plugin(Arc::new(
                 wash_runtime::washlet::plugins::wasi_logging::TracingLogging::default(),

--- a/crates/wash/src/cli/mod.rs
+++ b/crates/wash/src/cli/mod.rs
@@ -22,7 +22,7 @@ use tracing::{debug, error, info, instrument, trace};
 use serde::{Deserialize, Serialize};
 use wash_runtime::{
     host::{Host, HostApi as _},
-    plugin::wasi_config::RuntimeConfig,
+    plugin::wasi_config::WasiConfig,
     types::{Component, Workload, WorkloadStartRequest, WorkloadState},
     wit::WitInterface,
 };
@@ -377,7 +377,7 @@ impl CliContextBuilder {
         let plugin_manager = Arc::new(PluginManager::new(self.non_interactive));
 
         let host = wash_runtime::host::Host::builder()
-            .with_plugin(Arc::new(RuntimeConfig::default()))?
+            .with_plugin(Arc::new(WasiConfig::default()))?
             .with_plugin(plugin_manager.clone())?
             .build()
             .context("failed to create wash runtime")?

--- a/tests/integration_http_counter_with_blobstore_fs.rs
+++ b/tests/integration_http_counter_with_blobstore_fs.rs
@@ -17,7 +17,7 @@ use wash_runtime::{
     engine::Engine,
     host::{HostApi, HostBuilder},
     plugin::{
-        wasi_config::RuntimeConfig, wasi_http::HttpServer, wasi_keyvalue::WasiKeyvalue,
+        wasi_config::WasiConfig, wasi_http::HttpServer, wasi_keyvalue::WasiKeyvalue,
         wasi_logging::WasiLogging,
     },
     types::{
@@ -59,7 +59,7 @@ async fn test_http_counter_with_blobstore_fs_plugin() -> Result<()> {
     let logging_plugin = WasiLogging {};
 
     // Create config plugin
-    let config_plugin = RuntimeConfig::default();
+    let config_plugin = WasiConfig::default();
 
     // Create plugin manager to provide wasmcloud:wash interfaces
     let plugin_manager = PluginManager::default();

--- a/tests/integration_wit.rs
+++ b/tests/integration_wit.rs
@@ -115,7 +115,7 @@ async fn test_update_selective_and_full() -> Result<()> {
 
 world example {
     import wasi:logging/logging@0.1.0-draft;
-    import wasi:config/runtime@0.2.0-draft;
+    import wasi:config/store@0.2.0-draft;
 }
 "#,
     )
@@ -186,7 +186,7 @@ async fn test_remove_workflow() -> Result<()> {
 
 world example {
     import wasi:logging/logging@0.1.0-draft;
-    import wasi:config/runtime@0.2.0-draft;
+    import wasi:config/store@0.2.0-draft;
 }
 "#,
     )
@@ -226,7 +226,7 @@ world example {
         "wasi:logging should be removed from world.wit"
     );
     assert!(
-        content.contains("import wasi:config/runtime"),
+        content.contains("import wasi:config/store"),
         "wasi:config should remain in world.wit"
     );
 

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -104,7 +104,7 @@ interface types {
     /// This is useful for passing information between commands and hooks, or for storing state that's accessed
     /// across multiple invocations of the plugin.
     ///
-    /// Plugin config key/value pairs are available both in this object and through wasi:config/runtime calls.
+    /// Plugin config key/value pairs are available both in this object and through wasi:config/store calls.
     ///
     /// This is a global store for all instances of the plugin and race contentions should be handled with care.
     /// The contents of the store are not persisted after wash's execution ends.
@@ -169,7 +169,7 @@ interface types {
         /// This is useful for passing information between commands and hooks, or for storing state that's accessed
         /// across multiple invocations of the plugin.
         ///
-        /// Plugin config key/value pairs are available both in this object and through wasi:config/runtime calls.
+        /// Plugin config key/value pairs are available both in this object and through wasi:config/store calls.
         ///
         /// This is a global store for all instances of the plugin and race contentions should be handled with care.
         /// The contents of the store are not persisted after wash's execution ends.


### PR DESCRIPTION
Primary driver here was I wanted to change the wash cli text away from the old runtime name.

CLI argument changed from `--runtime-config` to `--wasi-config`. I updated every internal ref I could find.
