### PR TITLE
refactor: handle bind failure

### DIFF
--- a/crates/wash-runtime/src/plugin/mod.rs
+++ b/crates/wash-runtime/src/plugin/mod.rs
@@ -158,10 +158,13 @@ pub trait HostPlugin: std::any::Any + Send + Sync + 'static {
     /// Called when a workload is being stopped or unbound from this plugin.
     ///
     /// This method allows plugins to clean up any resources associated with
-    /// the workload. The default implementation does nothing.
+    /// the workload. This can be called during binding failures (before resolution)
+    /// or during normal workload shutdown (after resolution).
+    ///
+    /// The default implementation does nothing.
     ///
     /// # Arguments
-    /// * `workload` - The workload being unbound
+    /// * `workload_id` - The ID of the workload being unbound
     /// * `interfaces` - The interfaces that were bound
     ///
     /// # Returns
@@ -171,7 +174,7 @@ pub trait HostPlugin: std::any::Any + Send + Sync + 'static {
     /// Returns an error if cleanup fails.
     async fn on_workload_unbind(
         &self,
-        _workload: &ResolvedWorkload,
+        _workload_id: &str,
         _interfaces: std::collections::HashSet<crate::wit::WitInterface>,
     ) -> anyhow::Result<()> {
         Ok(())

--- a/crates/wash-runtime/src/plugin/wasi_blobstore.rs
+++ b/crates/wash-runtime/src/plugin/wasi_blobstore.rs
@@ -19,7 +19,7 @@ use wasmtime_wasi::{
 
 use crate::{
     engine::ctx::Ctx,
-    engine::workload::{ResolvedWorkload, WorkloadComponent},
+    engine::workload::WorkloadComponent,
     plugin::HostPlugin,
     wit::{WitInterface, WitWorld},
 };
@@ -949,15 +949,14 @@ impl HostPlugin for WasiBlobstore {
 
     async fn on_workload_unbind(
         &self,
-        workload_handle: &ResolvedWorkload,
+        workload_id: &str,
         _interfaces: std::collections::HashSet<crate::wit::WitInterface>,
     ) -> anyhow::Result<()> {
-        let id = workload_handle.id();
         // Clean up storage for this workload
         let mut storage = self.storage.write().await;
-        storage.remove(id);
+        storage.remove(workload_id);
 
-        tracing::debug!("WasiBlobstore plugin unbound from workload '{id}'");
+        tracing::debug!("WasiBlobstore plugin unbound from workload '{workload_id}'");
 
         Ok(())
     }

--- a/crates/wash-runtime/src/plugin/wasi_http.rs
+++ b/crates/wash-runtime/src/plugin/wasi_http.rs
@@ -252,17 +252,17 @@ impl HostPlugin for HttpServer {
 
     async fn on_workload_unbind(
         &self,
-        workload: &ResolvedWorkload,
+        workload_id: &str,
         _interfaces: HashSet<WitInterface>,
     ) -> anyhow::Result<()> {
-        debug!(workload_id = workload.id(), "removing HTTP workload handle");
+        debug!(workload_id, "removing HTTP workload handle");
 
         // Remove from workload handles
         let mut handles_guard = self.workload_handles.write().await;
-        handles_guard.retain(|_, (handle, _, _)| handle.id() != workload.id());
+        handles_guard.retain(|_, (handle, _, _)| handle.id() != workload_id);
 
         // Remove from workload configs
-        self.workload_configs.write().await.remove(workload.id());
+        self.workload_configs.write().await.remove(workload_id);
 
         Ok(())
     }

--- a/crates/wash-runtime/src/plugin/wasi_keyvalue.rs
+++ b/crates/wash-runtime/src/plugin/wasi_keyvalue.rs
@@ -13,10 +13,7 @@ use tokio::sync::RwLock;
 use wasmtime::component::Resource;
 
 use crate::{
-    engine::{
-        ctx::Ctx,
-        workload::{ResolvedWorkload, WorkloadComponent},
-    },
+    engine::{ctx::Ctx, workload::WorkloadComponent},
     plugin::HostPlugin,
     wit::{WitInterface, WitWorld},
 };
@@ -475,15 +472,14 @@ impl HostPlugin for WasiKeyvalue {
 
     async fn on_workload_unbind(
         &self,
-        workload_handle: &ResolvedWorkload,
+        workload_id: &str,
         _interfaces: std::collections::HashSet<crate::wit::WitInterface>,
     ) -> anyhow::Result<()> {
-        let id = workload_handle.id();
         // Clean up storage for this workload
         let mut storage = self.storage.write().await;
-        storage.remove(id);
+        storage.remove(workload_id);
 
-        tracing::debug!("WasiKeyvalue plugin unbound from workload '{id}'");
+        tracing::debug!("WasiKeyvalue plugin unbound from workload '{workload_id}'");
 
         Ok(())
     }

--- a/crates/wash-runtime/src/washlet/plugins/mod.rs
+++ b/crates/wash-runtime/src/washlet/plugins/mod.rs
@@ -6,8 +6,9 @@ pub mod wasi_logging;
 pub mod wasmcloud_messaging;
 
 use std::collections::HashMap;
+use std::future::Future;
 
-use crate::engine::workload::{ResolvedWorkload, UnresolvedWorkload, WorkloadComponent};
+use crate::engine::workload::{UnresolvedWorkload, WorkloadComponent};
 
 /// A tracker for workloads and their components, allowing storage of associated
 /// data.
@@ -47,8 +48,8 @@ impl<T, Y> WorkloadTracker<T, Y> {
         );
     }
 
-    pub async fn remove_workload(&mut self, workload: &ResolvedWorkload) {
-        if let Some(item) = self.workloads.remove(workload.id()) {
+    pub async fn remove_workload(&mut self, workload_id: &str) {
+        if let Some(item) = self.workloads.remove(workload_id) {
             for component_id in item.components.keys() {
                 self.components.remove(component_id);
             }
@@ -60,11 +61,11 @@ impl<T, Y> WorkloadTracker<T, Y> {
         FutC: Future<Output = ()>,
     >(
         &mut self,
-        workload: &ResolvedWorkload,
+        workload_id: &str,
         workload_cleanup: impl FnOnce(Option<T>) -> FutW,
         component_cleanup: impl Fn(Y) -> FutC,
     ) {
-        if let Some(item) = self.workloads.remove(workload.id()) {
+        if let Some(item) = self.workloads.remove(workload_id) {
             for (component_id, component_data) in item.components {
                 component_cleanup(component_data).await;
                 self.components.remove(&component_id);

--- a/crates/wash-runtime/src/washlet/plugins/wasi_blobstore.rs
+++ b/crates/wash-runtime/src/washlet/plugins/wasi_blobstore.rs
@@ -4,7 +4,7 @@ use std::time::SystemTime;
 
 const PLUGIN_BLOBSTORE_ID: &str = "wasi-blobstore";
 use crate::engine::ctx::Ctx;
-use crate::engine::workload::{ResolvedWorkload, WorkloadComponent};
+use crate::engine::workload::WorkloadComponent;
 use crate::plugin::HostPlugin;
 use crate::wit::{WitInterface, WitWorld};
 use tokio::sync::RwLock;
@@ -959,15 +959,14 @@ impl HostPlugin for WasiBlobstore {
 
     async fn on_workload_unbind(
         &self,
-        workload_handle: &ResolvedWorkload,
+        workload_id: &str,
         _interfaces: std::collections::HashSet<crate::wit::WitInterface>,
     ) -> anyhow::Result<()> {
-        let id = workload_handle.id();
         // Clean up storage for this workload
         let mut storage = self.storage.write().await;
-        storage.remove(id);
+        storage.remove(workload_id);
 
-        tracing::debug!("WasiBlobstore plugin unbound from workload '{id}'");
+        tracing::debug!("WasiBlobstore plugin unbound from workload '{workload_id}'");
 
         Ok(())
     }

--- a/crates/wash-runtime/src/washlet/plugins/wasi_keyvalue.rs
+++ b/crates/wash-runtime/src/washlet/plugins/wasi_keyvalue.rs
@@ -11,7 +11,7 @@ use bytes::{Buf, Bytes};
 
 const PLUGIN_KEYVALUE_ID: &str = "wasi-keyvalue";
 use crate::engine::ctx::Ctx;
-use crate::engine::workload::{ResolvedWorkload, WorkloadComponent};
+use crate::engine::workload::WorkloadComponent;
 use crate::plugin::HostPlugin;
 use crate::wit::{WitInterface, WitWorld};
 use futures::StreamExt;
@@ -503,12 +503,10 @@ impl HostPlugin for WasiKeyvalue {
 
     async fn on_workload_unbind(
         &self,
-        workload_handle: &ResolvedWorkload,
+        workload_id: &str,
         _interfaces: std::collections::HashSet<crate::wit::WitInterface>,
     ) -> anyhow::Result<()> {
-        let id = workload_handle.id();
-
-        tracing::debug!("WasiKeyvalue plugin unbound from workload '{id}'");
+        tracing::debug!("WasiKeyvalue plugin unbound from workload '{workload_id}'");
 
         Ok(())
     }

--- a/crates/wash-runtime/src/washlet/plugins/wasmcloud_messaging.rs
+++ b/crates/wash-runtime/src/washlet/plugins/wasmcloud_messaging.rs
@@ -247,7 +247,7 @@ impl HostPlugin for WasmcloudMessaging {
 
     async fn on_workload_unbind(
         &self,
-        workload: &ResolvedWorkload,
+        workload_id: &str,
         _interfaces: HashSet<crate::wit::WitInterface>,
     ) -> anyhow::Result<()> {
         let workload_cleanup = |_| async {};
@@ -258,7 +258,7 @@ impl HostPlugin for WasmcloudMessaging {
         self.tracker
             .write()
             .await
-            .remove_workload_with_cleanup(workload, workload_cleanup, component_cleanup)
+            .remove_workload_with_cleanup(workload_id, workload_cleanup, component_cleanup)
             .await;
 
         Ok(())


### PR DESCRIPTION
Refactors on_workload_unbind to use workload id as all
cases and callers only every used id of the workload and
allow unbind to use UnResolvedWorkloads as well as Resolved.

The runtime ensures proper cleanup automatically in LIFO order

Fixes #128

Signed-off-by: Bailey Hayes <behayes2@gmail.com>
