### PR TITLE
fix: docker release tag (again)

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -130,7 +130,7 @@ jobs:
       push: true
       image: ghcr.io/wasmcloud/wash
       tags: |
-        type=semver,pattern={{version}}
+        type=match,pattern=wash-v(.*),group=1
 
   release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/wash-v')


### PR DESCRIPTION
as expected, the `wash-` prefix is picked  up by github action docker metadata.

This approach uses a regex instead.
https://github.com/docker/metadata-action?tab=readme-ov-file#typematch