### PR TITLE
fix: noninteractive check

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -235,7 +235,7 @@ async fn main() {
     let mut stdout_buf = BufWriter::new(stdout);
 
     // Recommend a new version of wash if available
-    if !cli.non_interactive &&
+    if !non_interactive &&
         ctx
         .check_new_version()
         .await


### PR DESCRIPTION
Fixes #142

 The code was checking cli.non_interactive (which only reflects the --non-interactive flag) instead of the non_interactive variable that includes both the flag and the auto-detection based on whether stdin is a TTY.