### PR TITLE
feat: NATS blobstore

### DIFF
--- a/crates/wash-runtime/src/washlet/plugins/wasi_blobstore.rs
+++ b/crates/wash-runtime/src/washlet/plugins/wasi_blobstore.rs
@@ -672,7 +672,7 @@ impl bindings::wasi::blobstore::types::HostOutgoingValue for Ctx {
         // read in finish()
         let boxed: Box<dyn OutputStream> = Box::new(stream);
 
-        let resource = self.table.push_child(boxed, &outgoing_value)?;
+        let resource = self.table.push(boxed)?;
         Ok(Ok(resource))
     }
 

--- a/crates/wash-runtime/src/washlet/plugins/wasi_blobstore.rs
+++ b/crates/wash-runtime/src/washlet/plugins/wasi_blobstore.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::f64::consts::E;
 use std::sync::Arc;
 use std::time::SystemTime;
 
@@ -6,11 +7,18 @@ const PLUGIN_BLOBSTORE_ID: &str = "wasi-blobstore";
 use crate::engine::ctx::Ctx;
 use crate::engine::workload::WorkloadComponent;
 use crate::plugin::HostPlugin;
+use crate::washlet::plugins::WorkloadTracker;
 use crate::wit::{WitInterface, WitWorld};
+use anyhow::Context;
+use async_nats::jetstream::object_store::{self, List, Object, ObjectStore};
+use futures::{StreamExt, TryStreamExt};
+use tokio::io::AsyncReadExt;
 use tokio::sync::RwLock;
 use wasmtime::component::Resource;
-use wasmtime_wasi::pipe::{MemoryInputPipe, MemoryOutputPipe};
+use wasmtime_wasi::pipe::{self, MemoryInputPipe, MemoryOutputPipe};
 use wasmtime_wasi::{InputStream, OutputStream};
+
+const MAX_FILE_UPLOAD_SIZE: usize = 2 * 1024 * 1024 * 1024; // 2 GiB
 
 mod bindings {
     wasmtime::component::bindgen!({
@@ -19,7 +27,7 @@ mod bindings {
         async: true,
         with: {
             "wasi:io": ::wasmtime_wasi::bindings::io,
-            "wasi:blobstore/container/container": String,
+            "wasi:blobstore/container/container": crate::washlet::plugins::wasi_blobstore::ContainerData,
             "wasi:blobstore/container/stream-object-names": crate::washlet::plugins::wasi_blobstore::StreamObjectNamesHandle,
             "wasi:blobstore/types/incoming-value": crate::washlet::plugins::wasi_blobstore::IncomingValueHandle,
             "wasi:blobstore/types/outgoing-value": crate::washlet::plugins::wasi_blobstore::OutgoingValueHandle,
@@ -42,48 +50,81 @@ pub struct ObjectData {
 }
 
 /// In-memory container representation
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct ContainerData {
     pub name: String,
-    pub created_at: u64,
-    pub objects: HashMap<String, ObjectData>,
+    pub store: ObjectStore,
+}
+
+pub struct WorkloadData {
+    /// Which buckets (containers) are accessible to this workload
+    pub buckets: HashSet<String>,
+    /// Whether the blobstore is read-only for this workload
+    pub read_only: bool,
+    /// Cancellation token for any ongoing operations
+    pub cancel_token: tokio_util::sync::CancellationToken,
 }
 
 /// Resource representation for an incoming value (data being read)
-pub type IncomingValueHandle = Vec<u8>;
+pub struct IncomingValueHandle {
+    pub object: Object,
+    pub start: u64,
+    pub end: u64,
+}
 
 /// Resource representation for an outgoing value (data being written)
+/// The operation is delayed until `finish` is called
 pub struct OutgoingValueHandle {
-    pub pipe: MemoryOutputPipe,
-    pub container_name: Option<String>,
+    pub temp_file: tempfile::NamedTempFile,
+    pub container: Option<ContainerData>,
     pub object_name: Option<String>,
 }
 
 /// Resource representation for streaming object names
-#[derive(Debug)]
 pub struct StreamObjectNamesHandle {
-    pub objects: Vec<String>,
+    pub objects: List,
     pub position: usize,
 }
 
-/// Memory-based blobstore plugin
-#[derive(Clone, Default)]
+/// NATS blobstore plugin
+#[derive(Clone)]
 pub struct WasiBlobstore {
-    /// Storage for all containers, keyed by workload ID
-    storage: Arc<RwLock<HashMap<String, HashMap<String, ContainerData>>>>,
-    /// The maximum size for objects stored in the blobstore
-    max_object_size: usize,
+    client: Arc<async_nats::jetstream::Context>,
+    tracker: Arc<RwLock<WorkloadTracker<WorkloadData, ()>>>,
 }
 
 impl WasiBlobstore {
-    pub fn new(max_object_size: Option<usize>) -> Self {
+    pub fn new(client: Arc<async_nats::Client>) -> Self {
         Self {
-            storage: Arc::new(RwLock::new(HashMap::new())),
-            max_object_size: max_object_size.unwrap_or(1_000_000), // 1mb limit by default
+            client: async_nats::jetstream::new((*client).clone()).into(),
+            tracker: Arc::default(),
         }
     }
 
-    fn get_timestamp() -> u64 {
+    async fn workload_permit(
+        &self,
+        workload_id: &str,
+        container_name: &str,
+        is_write: bool,
+    ) -> Option<tokio_util::sync::CancellationToken> {
+        let tracker = self.tracker.read().await;
+        match tracker.workloads.get(workload_id) {
+            Some(item) => {
+                if let Some(data) = &item.workload_data {
+                    if data.buckets.contains(container_name) {
+                        return Some(data.cancel_token.clone());
+                    }
+                    if is_write && data.read_only {
+                        return None;
+                    }
+                }
+                None
+            }
+            None => None,
+        }
+    }
+
+    fn default_create_timestamp() -> u64 {
         SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap_or_default()
@@ -96,48 +137,72 @@ impl bindings::wasi::blobstore::blobstore::Host for Ctx {
     async fn create_container(
         &mut self,
         name: ContainerName,
-    ) -> anyhow::Result<Result<Resource<String>, BlobstoreError>> {
+    ) -> anyhow::Result<Result<Resource<ContainerData>, BlobstoreError>> {
         let Some(plugin) = self.get_plugin::<WasiBlobstore>(PLUGIN_BLOBSTORE_ID) else {
             return Ok(Err("blobstore plugin not available".to_string()));
         };
 
-        let mut storage = plugin.storage.write().await;
-        let workload_storage = storage.entry(self.workload_id.to_string()).or_default();
+        let _workload_permit = match plugin.workload_permit(&self.workload_id, &name, true).await {
+            Some(token) => token,
+            None => {
+                return Ok(Err("unauthorized".to_string()));
+            }
+        };
 
-        if workload_storage.contains_key(&name) {
-            return Ok(Err(format!("container '{name}' already exists")));
-        }
+        let store = match plugin
+            .client
+            .create_object_store(object_store::Config {
+                bucket: name.to_string(),
+                ..Default::default()
+            })
+            .await
+        {
+            Ok(store) => store,
+            Err(e) => {
+                return Ok(Err(format!("failed to create bucket: {e}")));
+            }
+        };
 
         let container_data = ContainerData {
             name: name.clone(),
-            created_at: WasiBlobstore::get_timestamp(),
-            objects: HashMap::new(),
+            store,
         };
 
-        workload_storage.insert(name.clone(), container_data);
-        let resource = self.table.push(name)?;
+        let resource = self.table.push(container_data)?;
         Ok(Ok(resource))
     }
 
     async fn get_container(
         &mut self,
         name: ContainerName,
-    ) -> anyhow::Result<Result<Resource<String>, BlobstoreError>> {
+    ) -> anyhow::Result<Result<Resource<ContainerData>, BlobstoreError>> {
         let Some(plugin) = self.get_plugin::<WasiBlobstore>(PLUGIN_BLOBSTORE_ID) else {
             return Ok(Err("blobstore plugin not available".to_string()));
         };
 
-        let storage = plugin.storage.read().await;
-        let empty_map = HashMap::new();
-        let workload_storage = storage
-            .get(&self.workload_id.to_string())
-            .unwrap_or(&empty_map);
+        let _workload_permit = match plugin
+            .workload_permit(&self.workload_id, &name, false)
+            .await
+        {
+            Some(token) => token,
+            None => {
+                return Ok(Err("unauthorized".to_string()));
+            }
+        };
 
-        if !workload_storage.contains_key(&name) {
-            return Ok(Err(format!("container '{name}' does not exist")));
-        }
+        let store = match plugin.client.get_object_store(name.to_string()).await {
+            Ok(store) => store,
+            Err(e) => {
+                return Ok(Err(format!("failed to get bucket: {e}")));
+            }
+        };
 
-        let resource = self.table.push(name)?;
+        let container_data = ContainerData {
+            name: name.clone(),
+            store,
+        };
+
+        let resource = self.table.push(container_data)?;
         Ok(Ok(resource))
     }
 
@@ -149,10 +214,17 @@ impl bindings::wasi::blobstore::blobstore::Host for Ctx {
             return Ok(Err("blobstore plugin not available".to_string()));
         };
 
-        let mut storage = plugin.storage.write().await;
-        let workload_storage = storage.entry(self.workload_id.to_string()).or_default();
+        let _workload_permit = match plugin.workload_permit(&self.workload_id, &name, true).await {
+            Some(token) => token,
+            None => {
+                return Ok(Err("unauthorized".to_string()));
+            }
+        };
 
-        workload_storage.remove(&name);
+        if let Err(e) = plugin.client.delete_object_store(name.to_string()).await {
+            return Ok(Err(format!("failed to delete bucket: {e}")));
+        };
+
         Ok(Ok(()))
     }
 
@@ -164,13 +236,17 @@ impl bindings::wasi::blobstore::blobstore::Host for Ctx {
             return Ok(Err("blobstore plugin not available".to_string()));
         };
 
-        let storage = plugin.storage.read().await;
-        let empty_map = HashMap::new();
-        let workload_storage = storage
-            .get(&self.workload_id.to_string())
-            .unwrap_or(&empty_map);
+        let _workload_permit = match plugin.workload_permit(&self.workload_id, &name, true).await {
+            Some(token) => token,
+            None => {
+                return Ok(Err("unauthorized".to_string()));
+            }
+        };
 
-        Ok(Ok(workload_storage.contains_key(&name)))
+        match plugin.client.get_object_store(name.to_string()).await {
+            Ok(_) => Ok(Ok(true)),
+            Err(_) => Ok(Ok(false)),
+        }
     }
 
     async fn copy_object(
@@ -182,50 +258,49 @@ impl bindings::wasi::blobstore::blobstore::Host for Ctx {
             return Ok(Err("blobstore plugin not available".to_string()));
         };
 
-        let mut storage = plugin.storage.write().await;
-        let workload_storage = storage.entry(self.workload_id.to_string()).or_default();
-
-        // Get source object data (clone to avoid borrow conflicts)
-        let src_object_data = {
-            let src_container = match workload_storage.get(&src.container) {
-                Some(container) => container,
-                None => {
-                    return Ok(Err(format!(
-                        "source container '{}' does not exist",
-                        src.container
-                    )));
-                }
-            };
-
-            match src_container.objects.get(&src.object) {
-                Some(object) => object.clone(),
-                None => {
-                    return Ok(Err(format!(
-                        "source object '{}' does not exist",
-                        src.object
-                    )));
-                }
-            }
-        };
-
-        // Ensure destination container exists and copy object
-        let dest_container = match workload_storage.get_mut(&dest.container) {
-            Some(container) => container,
+        let _read_permit = match plugin
+            .workload_permit(&self.workload_id, &src.container, false)
+            .await
+        {
+            Some(token) => token,
             None => {
-                return Ok(Err(format!(
-                    "destination container '{}' does not exist",
-                    dest.container
-                )));
+                return Ok(Err("unauthorized read".to_string()));
             }
         };
 
-        let mut copied_object = src_object_data;
-        copied_object.name = dest.object.clone();
-        copied_object.container = dest.container.clone();
-        copied_object.created_at = WasiBlobstore::get_timestamp();
+        let _write_permit = match plugin
+            .workload_permit(&self.workload_id, &dest.container, true)
+            .await
+        {
+            Some(token) => token,
+            None => {
+                return Ok(Err("unauthorized write".to_string()));
+            }
+        };
 
-        dest_container.objects.insert(dest.object, copied_object);
-        Ok(Ok(()))
+        let read_store = match plugin.client.get_object_store(src.container.clone()).await {
+            Ok(store) => store,
+            Err(e) => {
+                return Ok(Err(format!("failed to get source bucket: {e}")));
+            }
+        };
+
+        let write_store = match plugin.client.get_object_store(dest.container.clone()).await {
+            Ok(store) => store,
+            Err(e) => {
+                return Ok(Err(format!("failed to get destination bucket: {e}")));
+            }
+        };
+
+        match read_store.get(&src.object).await {
+            Ok(mut object) => match write_store.put(dest.object.as_str(), &mut object).await {
+                Ok(_) => Ok(Ok(())),
+                Err(e) => Ok(Err(format!(
+                    "failed to write data to destination object: {e}"
+                ))),
+            },
+            Err(e) => Ok(Err(format!("failed to get source object: {e}"))),
+        }
     }
 
     async fn move_object(
@@ -233,339 +308,277 @@ impl bindings::wasi::blobstore::blobstore::Host for Ctx {
         src: ObjectId,
         dest: ObjectId,
     ) -> anyhow::Result<Result<(), BlobstoreError>> {
-        // First copy the object
-        let _ = self.copy_object(src.clone(), dest).await?;
-
         let Some(plugin) = self.get_plugin::<WasiBlobstore>(PLUGIN_BLOBSTORE_ID) else {
             return Ok(Err("blobstore plugin not available".to_string()));
         };
 
-        // Then delete the source
-        let mut storage = plugin.storage.write().await;
-        let workload_storage = storage.entry(self.workload_id.to_string()).or_default();
-
-        if let Some(src_container) = workload_storage.get_mut(&src.container) {
-            src_container.objects.remove(&src.object);
+        // requires an extra write permit on the src container to delete the object after copy
+        let _write_permit = match plugin
+            .workload_permit(&self.workload_id, &src.container, true)
+            .await
+        {
+            Some(token) => token,
+            None => {
+                return Ok(Err("unauthorized delete".to_string()));
+            }
+        };
+        let delete_store = match plugin.client.get_object_store(src.container.clone()).await {
+            Ok(store) => store,
+            Err(e) => {
+                return Ok(Err(format!("failed to get source bucket: {e}")));
+            }
+        };
+        self.copy_object(src.clone(), dest.clone()).await?;
+        match delete_store.delete(src.object.as_str()).await {
+            Ok(_) => Ok(Ok(())),
+            Err(e) => Ok(Err(format!("failed to delete source object: {e}"))),
         }
-
-        Ok(Ok(()))
     }
 }
 
-// Resource host trait implementations - these handle the lifecycle of each
-// resource type
 impl bindings::wasi::blobstore::container::HostContainer for Ctx {
     async fn name(
         &mut self,
-        container: Resource<String>,
+        container: Resource<ContainerData>,
     ) -> anyhow::Result<Result<String, ContainerError>> {
-        let container_name = self.table.get(&container)?;
-        Ok(Ok(container_name.clone()))
+        let container_data = self.table.get(&container)?;
+        Ok(Ok(container_data.name.clone()))
     }
 
     async fn info(
         &mut self,
-        container: Resource<String>,
+        container: Resource<ContainerData>,
     ) -> anyhow::Result<Result<ContainerMetadata, ContainerError>> {
-        let container_name = self.table.get(&container)?;
+        let container_data = self.table.get(&container)?;
 
-        let Some(plugin) = self.get_plugin::<WasiBlobstore>(PLUGIN_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
-
-        let storage = plugin.storage.read().await;
-        let empty_map = HashMap::new();
-        let workload_storage = storage
-            .get(&self.workload_id.to_string())
-            .unwrap_or(&empty_map);
-
-        match workload_storage.get(container_name) {
-            Some(container_data) => Ok(Ok(ContainerMetadata {
-                name: container_data.name.clone(),
-                created_at: container_data.created_at,
-            })),
-            None => Ok(Err(format!("container '{container_name}' does not exist"))),
-        }
+        Ok(Ok(ContainerMetadata {
+            name: container_data.name.clone(),
+            created_at: 0,
+        }))
     }
 
     async fn get_data(
         &mut self,
-        container: Resource<String>,
+        container: Resource<ContainerData>,
         name: ObjectName,
         start: u64,
         end: u64,
     ) -> anyhow::Result<Result<Resource<IncomingValueHandle>, ContainerError>> {
-        let container_name = self.table.get(&container)?;
+        let container_data = self.table.get(&container)?;
 
-        tracing::debug!(
-            container = container_name,
-            object = name,
-            start = start,
-            end = end,
-            workload_id = self.workload_id.as_ref(),
-            "Getting object data from container"
-        );
-
-        let Some(plugin) = self.get_plugin::<WasiBlobstore>(PLUGIN_BLOBSTORE_ID) else {
-            tracing::error!("blobstore plugin not available for get_data");
-            return Ok(Err("blobstore plugin not available".to_string()));
+        let object = match container_data.store.get(name.as_str()).await {
+            Ok(obj) => obj,
+            Err(e) => {
+                tracing::warn!(
+                    container = container_data.name,
+                    object = name,
+                    "Failed to get object from store: {e}"
+                );
+                return Ok(Err(format!("object '{name}' does not exist")));
+            }
         };
 
-        let storage = plugin.storage.read().await;
-        let empty_map = HashMap::new();
-        let workload_storage = storage
-            .get(&self.workload_id.to_string())
-            .unwrap_or(&empty_map);
+        let resource = self
+            .table
+            .push(IncomingValueHandle { object, start, end })?;
 
-        match workload_storage.get(container_name) {
-            Some(container_data) => match container_data.objects.get(&name) {
-                Some(object_data) => {
-                    let start_idx = start.min(object_data.data.len() as u64) as usize;
-                    let end_idx = end.min(object_data.data.len() as u64) as usize;
-                    let data_slice = object_data.data[start_idx..end_idx].to_vec();
-
-                    tracing::debug!(
-                        container = container_name,
-                        object = name,
-                        original_size = object_data.data.len(),
-                        slice_size = data_slice.len(),
-                        start_idx = start_idx,
-                        end_idx = end_idx,
-                        "Retrieved object data slice"
-                    );
-
-                    let resource = self.table.push(data_slice)?;
-                    Ok(Ok(resource))
-                }
-                None => {
-                    tracing::warn!(
-                        container = container_name,
-                        object = name,
-                        "Object does not exist in container"
-                    );
-                    Ok(Err(format!("object '{name}' does not exist")))
-                }
-            },
-            None => {
-                tracing::warn!(
-                    container = container_name,
-                    workload_id = self.workload_id.as_ref(),
-                    "Container does not exist for workload"
-                );
-                Ok(Err(format!("container '{container_name}' does not exist")))
-            }
-        }
+        Ok(Ok(resource))
     }
 
     async fn write_data(
         &mut self,
-        container: Resource<String>,
+        container: Resource<ContainerData>,
         name: ObjectName,
         data: Resource<OutgoingValueHandle>,
     ) -> anyhow::Result<Result<(), ContainerError>> {
-        let container_name = self.table.get(&container)?.clone();
-
-        tracing::debug!(
-            container = container_name,
-            object = name,
-            workload_id = self.workload_id.as_ref(),
-            "Initiating write_data for object"
-        );
-
         let Some(plugin) = self.get_plugin::<WasiBlobstore>(PLUGIN_BLOBSTORE_ID) else {
-            tracing::error!("blobstore plugin not available for write_data");
             return Ok(Err("blobstore plugin not available".to_string()));
         };
 
-        // Verify the container exists
-        let storage = plugin.storage.read().await;
-        let empty_map = HashMap::new();
-        let workload_storage = storage
-            .get(&self.workload_id.to_string())
-            .unwrap_or(&empty_map);
+        let container_data = self.table.get(&container).cloned()?;
+        let _write_permit = match plugin
+            .workload_permit(&self.workload_id, &container_data.name, true)
+            .await
+        {
+            Some(token) => token,
+            None => {
+                return Ok(Err("unauthorized write".to_string()));
+            }
+        };
 
-        if !workload_storage.contains_key(&container_name) {
-            tracing::warn!(
-                container = container_name,
-                workload_id = self.workload_id.as_ref(),
-                "Container does not exist for write_data"
-            );
-            return Ok(Err(format!("container '{container_name}' does not exist")));
-        }
-        drop(storage);
-
-        // Store the container and object names - actual writing happens in finish()
-        let outgoing_handle = self.table.get_mut(&data)?;
-        outgoing_handle.container_name = Some(container_name.clone());
-        outgoing_handle.object_name = Some(name.clone());
-
-        tracing::debug!(
-            container = container_name,
-            object = name,
-            "write_data setup complete, actual write will happen in finish()"
-        );
+        // prepare the write operation
+        // it actually happens on 'finish'
+        let handle = self.table.get_mut(&data)?;
+        handle.container = Some(container_data);
+        handle.object_name = Some(name.as_str().to_string());
 
         Ok(Ok(()))
     }
 
     async fn list_objects(
         &mut self,
-        container: Resource<String>,
+        container: Resource<ContainerData>,
     ) -> anyhow::Result<Result<Resource<StreamObjectNamesHandle>, ContainerError>> {
-        let container_name = self.table.get(&container)?;
+        let container_data = self.table.get(&container)?;
 
-        let Some(plugin) = self.get_plugin::<WasiBlobstore>(PLUGIN_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
+        let list_names = match container_data.store.list().await {
+            Ok(names) => names,
+            Err(e) => {
+                return Ok(Err(format!(
+                    "failed to list objects in container '{}'",
+                    container_data.name
+                )));
+            }
         };
 
-        let storage = plugin.storage.read().await;
-        let empty_map = HashMap::new();
-        let workload_storage = storage
-            .get(&self.workload_id.to_string())
-            .unwrap_or(&empty_map);
+        let resource = self.table.push(StreamObjectNamesHandle {
+            objects: list_names,
+            position: 0,
+        })?;
 
-        match workload_storage.get(container_name) {
-            Some(container_data) => {
-                let objects: Vec<String> = container_data.objects.keys().cloned().collect();
-                let handle = StreamObjectNamesHandle {
-                    objects,
-                    position: 0,
-                };
-                let resource = self.table.push(handle)?;
-                Ok(Ok(resource))
-            }
-            None => Ok(Err(format!("container '{container_name}' does not exist"))),
-        }
+        Ok(Ok(resource))
     }
 
     async fn delete_object(
         &mut self,
-        container: Resource<String>,
+        container: Resource<ContainerData>,
         name: ObjectName,
     ) -> anyhow::Result<Result<(), ContainerError>> {
-        let container_name = self.table.get(&container)?;
-
         let Some(plugin) = self.get_plugin::<WasiBlobstore>(PLUGIN_BLOBSTORE_ID) else {
             return Ok(Err("blobstore plugin not available".to_string()));
         };
 
-        let mut storage = plugin.storage.write().await;
-        let workload_storage = storage.entry(self.workload_id.to_string()).or_default();
-
-        match workload_storage.get_mut(container_name) {
-            Some(container_data) => {
-                container_data.objects.remove(&name);
-                Ok(Ok(()))
+        let container_data = self.table.get(&container)?;
+        let _write_permit = match plugin
+            .workload_permit(&self.workload_id, &container_data.name, true)
+            .await
+        {
+            Some(token) => token,
+            None => {
+                return Ok(Err("unauthorized write".to_string()));
             }
-            None => Ok(Err(format!("container '{container_name}' does not exist"))),
+        };
+
+        match container_data.store.delete(name.as_str()).await {
+            Ok(_) => Ok(Ok(())),
+            Err(e) => Ok(Err(format!("failed to delete object: {e}"))),
         }
     }
 
     async fn delete_objects(
         &mut self,
-        container: Resource<String>,
+        container: Resource<ContainerData>,
         names: Vec<ObjectName>,
     ) -> anyhow::Result<Result<(), ContainerError>> {
-        let container_name = self.table.get(&container)?;
-
         let Some(plugin) = self.get_plugin::<WasiBlobstore>(PLUGIN_BLOBSTORE_ID) else {
             return Ok(Err("blobstore plugin not available".to_string()));
         };
 
-        let mut storage = plugin.storage.write().await;
-        let workload_storage = storage.entry(self.workload_id.to_string()).or_default();
-
-        match workload_storage.get_mut(container_name) {
-            Some(container_data) => {
-                for name in names {
-                    container_data.objects.remove(&name);
-                }
-                Ok(Ok(()))
+        let container_data = self.table.get(&container)?;
+        let _write_permit = match plugin
+            .workload_permit(&self.workload_id, &container_data.name, true)
+            .await
+        {
+            Some(token) => token,
+            None => {
+                return Ok(Err("unauthorized write".to_string()));
             }
-            None => Ok(Err(format!("container '{container_name}' does not exist"))),
+        };
+
+        for name in names {
+            if let Err(e) = container_data.store.delete(name.as_str()).await {
+                return Ok(Err(format!("failed to delete object: {e}")));
+            }
         }
+
+        Ok(Ok(()))
     }
 
     async fn has_object(
         &mut self,
-        container: Resource<String>,
+        container: Resource<ContainerData>,
         name: ObjectName,
     ) -> anyhow::Result<Result<bool, ContainerError>> {
-        let container_name = self.table.get(&container)?;
-
-        let Some(plugin) = self.get_plugin::<WasiBlobstore>(PLUGIN_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
-
-        let storage = plugin.storage.read().await;
-        let empty_map = HashMap::new();
-        let workload_storage = storage
-            .get(&self.workload_id.to_string())
-            .unwrap_or(&empty_map);
-
-        match workload_storage.get(container_name) {
-            Some(container_data) => Ok(Ok(container_data.objects.contains_key(&name))),
-            None => Ok(Err(format!("container '{container_name}' does not exist"))),
+        let container_data = self.table.get(&container)?;
+        match container_data.store.info(name.as_str()).await {
+            Ok(_) => Ok(Ok(true)),
+            Err(_) => Ok(Ok(false)),
         }
     }
 
     async fn object_info(
         &mut self,
-        container: Resource<String>,
+        container: Resource<ContainerData>,
         name: ObjectName,
     ) -> anyhow::Result<Result<ObjectMetadata, ContainerError>> {
-        let container_name = self.table.get(&container)?;
-
-        let Some(plugin) = self.get_plugin::<WasiBlobstore>(PLUGIN_BLOBSTORE_ID) else {
-            return Ok(Err("blobstore plugin not available".to_string()));
-        };
-
-        let storage = plugin.storage.read().await;
-        let empty_map = HashMap::new();
-        let workload_storage = storage
-            .get(&self.workload_id.to_string())
-            .unwrap_or(&empty_map);
-
-        match workload_storage.get(container_name) {
-            Some(container_data) => match container_data.objects.get(&name) {
-                Some(object_data) => Ok(Ok(ObjectMetadata {
-                    name: object_data.name.clone(),
-                    container: object_data.container.clone(),
-                    created_at: object_data.created_at,
-                    size: object_data.data.len() as u64,
-                })),
-                None => Ok(Err(format!("object '{name}' does not exist"))),
-            },
-            None => Ok(Err(format!("container '{container_name}' does not exist"))),
+        let container_data = self.table.get(&container)?;
+        match container_data.store.info(name.as_str()).await {
+            Ok(info) => Ok(Ok(ObjectMetadata {
+                name: info.name,
+                container: container_data.name.clone(),
+                created_at: 0,
+                size: info.size as u64,
+            })),
+            Err(_) => Ok(Err(format!("object '{name}' does not exist"))),
         }
     }
 
     async fn clear(
         &mut self,
-        container: Resource<String>,
+        container: Resource<ContainerData>,
     ) -> anyhow::Result<Result<(), ContainerError>> {
-        let container_name = self.table.get(&container)?;
-
         let Some(plugin) = self.get_plugin::<WasiBlobstore>(PLUGIN_BLOBSTORE_ID) else {
             return Ok(Err("blobstore plugin not available".to_string()));
         };
 
-        let mut storage = plugin.storage.write().await;
-        let workload_storage = storage.entry(self.workload_id.to_string()).or_default();
-
-        match workload_storage.get_mut(container_name) {
-            Some(container_data) => {
-                container_data.objects.clear();
-                Ok(Ok(()))
+        let container_data = self.table.get(&container)?;
+        let _write_permit = match plugin
+            .workload_permit(&self.workload_id, &container_data.name, true)
+            .await
+        {
+            Some(token) => token,
+            None => {
+                return Ok(Err("unauthorized delete".to_string()));
             }
-            None => Ok(Err(format!("container '{container_name}' does not exist"))),
+        };
+
+        let mut object_list = match container_data.store.list().await {
+            Ok(list) => list,
+            Err(e) => {
+                return Ok(Err(format!(
+                    "failed to list objects in container '{}': {e}",
+                    container_data.name
+                )));
+            }
+        };
+
+        while let Some(object) = object_list.next().await {
+            match object {
+                Ok(obj) => {
+                    if let Err(e) = container_data.store.delete(&obj.name).await {
+                        return Ok(Err(format!(
+                            "failed to delete object '{}' in container '{}': {e}",
+                            obj.name, container_data.name
+                        )));
+                    }
+                }
+                Err(e) => {
+                    return Ok(Err(format!(
+                        "failed to list objects in container '{}': {e}",
+                        container_data.name
+                    )));
+                }
+            };
         }
+
+        Ok(Ok(()))
     }
 
-    async fn drop(&mut self, rep: Resource<String>) -> anyhow::Result<()> {
+    async fn drop(&mut self, rep: Resource<ContainerData>) -> anyhow::Result<()> {
         // Container resource cleanup - resource table handles this automatically
         tracing::debug!(
             workload_id = self.workload_id.as_ref(),
+            component_id = self.component_id.as_ref(),
             resource_id = ?rep,
             "Dropping container resource"
         );
@@ -582,23 +595,22 @@ impl bindings::wasi::blobstore::container::HostStreamObjectNames for Ctx {
     ) -> anyhow::Result<Result<(Vec<ObjectName>, bool), ContainerError>> {
         let stream_handle = self.table.get_mut(&stream)?;
 
-        let remaining = stream_handle
-            .objects
-            .len()
-            .saturating_sub(stream_handle.position);
-        let to_read = (len as usize).min(remaining);
-
-        let mut objects = Vec::new();
-        for i in 0..to_read {
-            if let Some(obj_name) = stream_handle.objects.get(stream_handle.position + i) {
-                objects.push(obj_name.clone());
+        let mut objects = Vec::<ObjectName>::new();
+        for _ in 0..len {
+            match stream_handle.objects.next().await {
+                Some(Ok(obj)) => {
+                    objects.push(obj.name);
+                }
+                Some(Err(e)) => {
+                    return Ok(Err(format!("failed to read object name from stream: {e}")));
+                }
+                None => {
+                    return Ok(Ok((objects, true)));
+                }
             }
         }
 
-        stream_handle.position += to_read;
-        let is_end = stream_handle.position >= stream_handle.objects.len();
-
-        Ok(Ok((objects, is_end)))
+        Ok(Ok((objects, false)))
     }
 
     async fn skip_stream_object_names(
@@ -608,22 +620,26 @@ impl bindings::wasi::blobstore::container::HostStreamObjectNames for Ctx {
     ) -> anyhow::Result<Result<(u64, bool), ContainerError>> {
         let stream_handle = self.table.get_mut(&stream)?;
 
-        let remaining = stream_handle
-            .objects
-            .len()
-            .saturating_sub(stream_handle.position);
-        let to_skip = (num as usize).min(remaining);
+        for i in 0..num {
+            match stream_handle.objects.next().await {
+                Some(Ok(_)) => {}
+                Some(Err(e)) => {
+                    return Ok(Err(format!("failed to read object name from stream: {e}")));
+                }
+                None => {
+                    return Ok(Ok((i, true)));
+                }
+            }
+        }
 
-        stream_handle.position += to_skip;
-        let is_end = stream_handle.position >= stream_handle.objects.len();
-
-        Ok(Ok((to_skip as u64, is_end)))
+        Ok(Ok((num, false)))
     }
 
     async fn drop(&mut self, rep: Resource<StreamObjectNamesHandle>) -> anyhow::Result<()> {
         // StreamObjectNames resource cleanup
         tracing::debug!(
             workload_id = self.workload_id.as_ref(),
+            component_id = self.component_id.as_ref(),
             resource_id = ?rep,
             "Dropping StreamObjectNames resource"
         );
@@ -634,194 +650,77 @@ impl bindings::wasi::blobstore::container::HostStreamObjectNames for Ctx {
 
 impl bindings::wasi::blobstore::types::HostOutgoingValue for Ctx {
     async fn new_outgoing_value(&mut self) -> anyhow::Result<Resource<OutgoingValueHandle>> {
-        tracing::debug!(
-            workload_id = self.workload_id.as_ref(),
-            "Creating new OutgoingValue"
-        );
-
-        let Some(plugin) = self.get_plugin::<WasiBlobstore>(PLUGIN_BLOBSTORE_ID) else {
-            tracing::error!("blobstore plugin not available in new_outgoing_value");
-            return Err(anyhow::anyhow!("blobstore plugin not available"));
-        };
+        let temp_file = tempfile::Builder::new()
+            .tempfile()
+            .context("failed to create buffer file")?;
 
         let handle = OutgoingValueHandle {
-            pipe: MemoryOutputPipe::new(plugin.max_object_size),
-            container_name: None,
+            temp_file,
+            container: None,
             object_name: None,
         };
 
-        tracing::debug!(
-            workload_id = self.workload_id.as_ref(),
-            pipe_capacity = plugin.max_object_size,
-            "Created OutgoingValueHandle with MemoryOutputPipe"
-        );
-
-        match self.table.push(handle) {
-            Ok(resource) => {
-                tracing::debug!(
-                    workload_id = self.workload_id.as_ref(),
-                    resource_id = ?resource,
-                    "Successfully pushed OutgoingValueHandle to resource table"
-                );
-                Ok(resource)
-            }
-            Err(e) => {
-                tracing::error!(
-                    workload_id = self.workload_id.as_ref(),
-                    error = ?e,
-                    "Failed to push OutgoingValueHandle to resource table in new_outgoing_value"
-                );
-                Err(e.into())
-            }
-        }
+        let resource = self.table.push(handle)?;
+        Ok(resource)
     }
 
     async fn outgoing_value_write_body(
         &mut self,
         outgoing_value: Resource<OutgoingValueHandle>,
     ) -> anyhow::Result<Result<Resource<bindings::wasi::io0_2_1::streams::OutputStream>, ()>> {
-        tracing::debug!(
-            workload_id = self.workload_id.as_ref(),
-            "outgoing_value_write_body called"
-        );
+        let handle = self.table.get_mut(&outgoing_value)?;
 
-        let handle = match self.table.get_mut(&outgoing_value) {
-            Ok(h) => {
-                tracing::debug!(
-                    workload_id = self.workload_id.as_ref(),
-                    "Successfully retrieved OutgoingValueHandle from table"
-                );
-                h
-            }
-            Err(e) => {
-                tracing::error!(
-                    workload_id = self.workload_id.as_ref(),
-                    error = ?e,
-                    "Failed to get OutgoingValueHandle from table"
-                );
-                return Err(e.into());
-            }
-        };
-
-        tracing::debug!(
-            workload_id = self.workload_id.as_ref(),
-            "Creating boxed OutputStream from pipe"
-        );
+        let file_wrapper = tokio::fs::File::from_std(handle.temp_file.reopen()?);
+        let stream = pipe::AsyncWriteStream::new(8192, file_wrapper);
 
         // Return the pipe as the output stream - this is the same pipe that will be
         // read in finish()
-        let boxed: Box<dyn OutputStream> = Box::new(handle.pipe.clone());
+        let boxed: Box<dyn OutputStream> = Box::new(stream);
 
-        tracing::debug!(
-            workload_id = self.workload_id.as_ref(),
-            "Attempting to push OutputStream to resource table"
-        );
-
-        match self.table.push(boxed) {
-            Ok(stream) => {
-                tracing::debug!(
-                    workload_id = self.workload_id.as_ref(),
-                    stream_resource_id = ?stream,
-                    "Successfully pushed OutputStream to resource table"
-                );
-                Ok(Ok(stream))
-            }
-            Err(e) => {
-                tracing::error!(
-                    workload_id = self.workload_id.as_ref(),
-                    error = ?e,
-                    error_type = std::any::type_name::<anyhow::Error>(),
-                    "Failed to push OutputStream to resource table - this is likely the TryFromIntError source"
-                );
-                Err(e.into())
-            }
-        }
+        let resource = self.table.push_child(boxed, &outgoing_value)?;
+        Ok(Ok(resource))
     }
 
     async fn finish(
         &mut self,
         outgoing_value: Resource<OutgoingValueHandle>,
     ) -> anyhow::Result<Result<(), BlobstoreError>> {
-        tracing::debug!(
-            workload_id = self.workload_id.as_ref(),
-            "finish() called for OutgoingValue"
-        );
-
         let handle = self.table.delete(outgoing_value)?;
-
-        tracing::debug!(
-            container_name = ?handle.container_name,
-            object_name = ?handle.object_name,
-            "Retrieved OutgoingValueHandle in finish()"
-        );
-
-        // If we have container and object names, perform the actual write
-        if let (Some(container_name), Some(object_name)) =
-            (&handle.container_name, &handle.object_name)
-        {
-            let Some(plugin) = self.get_plugin::<WasiBlobstore>(PLUGIN_BLOBSTORE_ID) else {
-                tracing::error!("blobstore plugin not available in finish()");
-                return Ok(Err("blobstore plugin not available".to_string()));
-            };
-
-            // Get the data from the pipe
-            let data_bytes = handle.pipe.contents();
-
-            tracing::debug!(
-                container = container_name,
-                object = object_name,
-                pipe_data_size = data_bytes.len(),
-                workload_id = self.workload_id.as_ref(),
-                "Retrieved data from pipe in finish()"
-            );
-
-            let mut storage = plugin.storage.write().await;
-            let workload_storage = storage.entry(self.workload_id.to_string()).or_default();
-
-            match workload_storage.get_mut(container_name) {
-                Some(container_data) => {
-                    let object_data = ObjectData {
-                        name: object_name.clone(),
-                        container: container_name.clone(),
-                        data: data_bytes.to_vec(),
-                        created_at: WasiBlobstore::get_timestamp(),
-                    };
-                    container_data
-                        .objects
-                        .insert(object_name.clone(), object_data);
-
-                    tracing::debug!(
-                        container = container_name,
-                        object = object_name,
-                        size = data_bytes.len(),
-                        "Stored object data to container"
-                    );
-                }
-                None => {
-                    tracing::error!(
-                        container = container_name,
-                        workload_id = self.workload_id.as_ref(),
-                        "Container does not exist in finish()"
-                    );
-                    return Ok(Err(format!("container '{container_name}' does not exist")));
-                }
+        let container_data = match handle.container {
+            Some(data) => data,
+            None => {
+                return Ok(Err(
+                    "outgoing value not associated with a container".to_string()
+                ));
             }
-        } else {
-            tracing::warn!(
-                workload_id = self.workload_id.as_ref(),
-                "finish() called without container/object names set"
-            );
+        };
+
+        let object_name = match handle.object_name {
+            Some(name) => name,
+            None => {
+                return Ok(Err(
+                    "outgoing value not associated with an object name".to_string()
+                ));
+            }
+        };
+
+        let mut file = tokio::fs::File::from_std(handle.temp_file.reopen()?);
+
+        match container_data
+            .store
+            .put(object_name.as_str(), &mut file)
+            .await
+        {
+            Ok(_) => {}
+            Err(e) => {
+                return Ok(Err(format!("failed to write object data: {e}")));
+            }
         }
 
         Ok(Ok(()))
     }
 
     async fn drop(&mut self, rep: Resource<OutgoingValueHandle>) -> anyhow::Result<()> {
-        tracing::debug!(
-            workload_id = self.workload_id.as_ref(),
-            resource_id = ?rep,
-            "Dropping OutgoingValue resource"
-        );
         self.table.delete(rep)?;
         Ok(())
     }
@@ -832,15 +731,13 @@ impl bindings::wasi::blobstore::types::HostIncomingValue for Ctx {
         &mut self,
         incoming_value: Resource<IncomingValueHandle>,
     ) -> anyhow::Result<Result<Vec<u8>, BlobstoreError>> {
-        let data = self.table.delete(incoming_value)?;
+        let mut data = self.table.delete(incoming_value)?;
+        let mut buf = Vec::new();
 
-        tracing::debug!(
-            workload_id = self.workload_id.as_ref(),
-            data_size = data.len(),
-            "incoming_value_consume_sync returning data"
-        );
-
-        Ok(Ok(data))
+        match data.object.read(&mut buf).await {
+            Ok(_) => Ok(Ok(buf)),
+            Err(e) => Ok(Err(format!("failed to read object data: {e}"))),
+        }
     }
 
     async fn incoming_value_consume_async(
@@ -849,28 +746,17 @@ impl bindings::wasi::blobstore::types::HostIncomingValue for Ctx {
     ) -> anyhow::Result<
         Result<Resource<bindings::wasi::blobstore::types::IncomingValueAsyncBody>, BlobstoreError>,
     > {
-        let data = self.table.get(&incoming_value)?;
+        let data = self.table.delete(incoming_value)?;
 
-        tracing::debug!(
-            workload_id = self.workload_id.as_ref(),
-            data_size = data.len(),
-            "incoming_value_consume_async creating MemoryInputPipe with data"
-        );
-
-        let stream: Box<dyn InputStream> = Box::new(MemoryInputPipe::new(data.clone()));
+        let stream: Box<dyn InputStream> = Box::new(pipe::AsyncReadStream::new(data.object));
         let stream = self.table.push(stream)?;
-
-        tracing::debug!(
-            workload_id = self.workload_id.as_ref(),
-            "incoming_value_consume_async created stream resource"
-        );
 
         Ok(Ok(stream))
     }
 
     async fn size(&mut self, incoming_value: Resource<IncomingValueHandle>) -> anyhow::Result<u64> {
         let data = self.table.get(&incoming_value)?;
-        Ok(data.len() as u64)
+        Ok(data.object.info().size as u64)
     }
 
     async fn drop(&mut self, rep: Resource<IncomingValueHandle>) -> anyhow::Result<()> {
@@ -883,11 +769,6 @@ impl bindings::wasi::blobstore::types::HostIncomingValue for Ctx {
         Ok(())
     }
 }
-
-// Note: wasi:io interface implementations are handled automatically by
-// wasmtime-wasi when setting up the Ctx during runtime initialization. The
-// bindgen-generated traits are sealed and can only be implemented on &mut _T
-// types.
 
 // Implement the main types Host trait that combines all resource types
 impl bindings::wasi::blobstore::types::Host for Ctx {}
@@ -914,26 +795,17 @@ impl HostPlugin for WasiBlobstore {
         component_handle: &mut WorkloadComponent,
         interfaces: std::collections::HashSet<crate::wit::WitInterface>,
     ) -> anyhow::Result<()> {
-        // Check if any of the interfaces are wasi:blobstore related
-        let has_blobstore = interfaces
+        let Some(_interface) = interfaces
             .iter()
-            .any(|i| i.namespace == "wasi" && i.package == "blobstore");
-
-        if !has_blobstore {
-            tracing::warn!(
-                "WasiBlobstore plugin requested for non-wasi:blobstore interface(s): {:?}",
-                interfaces
-            );
+            .find(|i| i.namespace == "wasi" && i.package == "blobstore")
+        else {
             return Ok(());
-        }
+        };
 
-        // Add blobstore interfaces to the workload's linker
-        // Note: wasi:io interfaces are already added by
-        // wasmtime_wasi::add_to_linker_async() in the engine initialization, so
-        // we only need to add the blobstore-specific interfaces
         tracing::debug!(
-            workload_id = component_handle.id(),
-            "Adding blobstore interfaces to linker for workload"
+            workload_id = component_handle.workload_id(),
+            component_id = component_handle.id(),
+            "Adding blobstore interfaces"
         );
         let linker = component_handle.linker();
 
@@ -941,18 +813,39 @@ impl HostPlugin for WasiBlobstore {
         bindings::wasi::blobstore::container::add_to_linker(linker, |ctx| ctx)?;
         bindings::wasi::blobstore::types::add_to_linker(linker, |ctx| ctx)?;
 
-        let id = component_handle.workload_id();
+        Ok(())
+    }
 
-        tracing::debug!(
-            workload_id = id,
-            "Successfully added blobstore interfaces to linker for workload"
+    async fn on_workload_bind(
+        &self,
+        workload: &crate::engine::workload::UnresolvedWorkload,
+        host_interfaces: std::collections::HashSet<crate::wit::WitInterface>,
+    ) -> anyhow::Result<()> {
+        let Some(interface) = host_interfaces
+            .iter()
+            .find(|i| i.namespace == "wasi" && i.package == "blobstore")
+        else {
+            return Ok(());
+        };
+
+        let buckets = match interface.config.get("buckets") {
+            Some(buckets) => buckets.split(',').map(|s| s.to_string()).collect(),
+            None => vec![],
+        };
+
+        let read_only = interface
+            .config
+            .get("read_only")
+            .map_or(false, |v| v == "true");
+
+        self.tracker.write().await.add_unresolved_workload(
+            workload,
+            WorkloadData {
+                buckets: HashSet::from_iter(buckets),
+                read_only,
+                cancel_token: tokio_util::sync::CancellationToken::new(),
+            },
         );
-
-        // Initialize storage for this workload
-        let mut storage = self.storage.write().await;
-        storage.insert(id.to_string(), HashMap::new());
-
-        tracing::debug!("WasiBlobstore plugin bound to workload '{id}'");
 
         Ok(())
     }
@@ -962,74 +855,19 @@ impl HostPlugin for WasiBlobstore {
         workload_id: &str,
         _interfaces: std::collections::HashSet<crate::wit::WitInterface>,
     ) -> anyhow::Result<()> {
-        // Clean up storage for this workload
-        let mut storage = self.storage.write().await;
-        storage.remove(workload_id);
+        let workload_cleanup = |workload_data: Option<WorkloadData>| async {
+            if let Some(data) = workload_data {
+                data.cancel_token.cancel();
+            }
+        };
+        let component_cleanup = |_| async move {};
 
-        tracing::debug!("WasiBlobstore plugin unbound from workload '{workload_id}'");
+        self.tracker
+            .write()
+            .await
+            .remove_workload_with_cleanup(workload_id, workload_cleanup, component_cleanup)
+            .await;
 
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_wasi_blobstore_creation() {
-        let blobstore = WasiBlobstore::new(None);
-        assert!(blobstore.storage.try_read().is_ok());
-    }
-
-    #[test]
-    fn test_get_timestamp() {
-        let timestamp = WasiBlobstore::get_timestamp();
-        assert!(timestamp > 0);
-    }
-
-    #[test]
-    fn test_object_data_creation() {
-        let data = ObjectData {
-            name: "test.txt".to_string(),
-            container: "test-container".to_string(),
-            data: b"hello world".to_vec(),
-            created_at: WasiBlobstore::get_timestamp(),
-        };
-
-        assert_eq!(data.name, "test.txt");
-        assert_eq!(data.container, "test-container");
-        assert_eq!(data.data, b"hello world");
-        assert!(data.created_at > 0);
-    }
-
-    #[test]
-    fn test_container_data_creation() {
-        let container = ContainerData {
-            name: "test-container".to_string(),
-            created_at: WasiBlobstore::get_timestamp(),
-            objects: HashMap::new(),
-        };
-
-        assert_eq!(container.name, "test-container");
-        assert!(container.created_at > 0);
-        assert!(container.objects.is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_storage_operations() {
-        let blobstore = WasiBlobstore::new(None);
-
-        // Test write access
-        {
-            let mut storage = blobstore.storage.write().await;
-            storage.insert("workload1".to_string(), HashMap::new());
-        }
-
-        // Test read access
-        {
-            let storage = blobstore.storage.read().await;
-            assert!(storage.contains_key("workload1"));
-        }
     }
 }

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -59,7 +59,9 @@ impl CliCommand for HostCommand {
                 wash_runtime::washlet::plugins::wasi_logging::TracingLogging::default(),
             ))?
             .with_plugin(Arc::new(
-                wash_runtime::washlet::plugins::wasi_blobstore::WasiBlobstore::new(None),
+                wash_runtime::washlet::plugins::wasi_blobstore::WasiBlobstore::new(
+                    data_nats_client.clone(),
+                ),
             ))?
             .with_plugin(Arc::new(
                 wash_runtime::washlet::plugins::wasmcloud_messaging::WasmcloudMessaging::new(


### PR DESCRIPTION
## Configuration

Uses the `data_nats` host connection.

`buckets: name1,name2,name3`
Which buckets this workload has access to.

`read_only: true|false` (default: false)
Blocks  `create`, `clear`, `delete` on Containers.
Blocks any `write` or `delete` operation in Objects.

## Implementation details

### Write Path

We buffer all bytes coming from WASM into a temporary file, executing the actual `put` operation during Output Stream `finish()`.

Using a temporary file instead of MemoryStream to remove file upload limits & also avoid increasing host memory usage, as the memory allocated by the plugin is not accounted towards the component memory ( not tied to wasmtime store ).

### Read Path

Bytes are piped directly when possible.