### PR TITLE
feat: Custom Build commands

### DIFF
--- a/crates/wash/src/component_build.rs
+++ b/crates/wash/src/component_build.rs
@@ -20,6 +20,10 @@ pub struct BuildConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub typescript: Option<TypeScriptBuildConfig>,
 
+    /// Custom build configuration
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub custom: Option<CustomBuildConfig>,
+
     /// Expected path to the built Wasm component artifact
     #[serde(skip_serializing_if = "Option::is_none")]
     pub component_path: Option<PathBuf>,
@@ -35,6 +39,8 @@ pub enum ProjectType {
     Go,
     /// TypeScript/JavaScript project (package.json found)
     TypeScript,
+    /// Custom project with user-defined build steps
+    Custom,
     /// Unknown project type
     Unknown,
 }
@@ -311,4 +317,11 @@ fn default_ts_package_manager() -> String {
 
 fn default_ts_build_command() -> String {
     "build".to_string()
+}
+
+/// Custom build configuration with explicit defaults
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CustomBuildConfig {
+    /// Custom build command
+    pub command: Vec<String>,
 }

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -15,7 +15,8 @@ use tracing::info;
 use crate::{
     cli::CONFIG_FILE_NAME,
     component_build::{
-        BuildConfig, ProjectType, RustBuildConfig, TinyGoBuildConfig, TypeScriptBuildConfig,
+        BuildConfig, CustomBuildConfig, ProjectType, RustBuildConfig, TinyGoBuildConfig,
+        TypeScriptBuildConfig,
     },
     new::NewTemplate,
     wit::WitConfig,
@@ -220,6 +221,14 @@ where
             if let Ok(ts_config) = figment.extract::<TypeScriptBuildConfig>() {
                 config.build = Some(BuildConfig {
                     typescript: Some(ts_config),
+                    ..Default::default()
+                });
+            }
+        }
+        ProjectType::Custom => {
+            if let Ok(custom_config) = figment.extract::<CustomBuildConfig>() {
+                config.build = Some(BuildConfig {
+                    custom: Some(custom_config),
                     ..Default::default()
                 });
             }


### PR DESCRIPTION
Allows custom build commands, for languages that cannot be auto-detected.

Example wash config ( project wide )

```
{
  "build": {
    "custom": {
      "command": ["cargo", "build", "--target=wasm32-wasip2", "--color=always"]
    }
  }
}
```