### PR TITLE
fix: Point Go Lint to the correct repo

### DIFF
--- a/.github/actions/lint-go/action.yaml
+++ b/.github/actions/lint-go/action.yaml
@@ -20,7 +20,7 @@ runs:
       working-directory: "${{ inputs.working-directory }}"
       run: "go mod tidy"
     - name: "Verify Go Mod Tidy"
-      uses: "wasmCloud/runtime-operator/.github/actions/no-diff@main"
+      uses: "wasmCloud/wash/.github/actions/no-diff@main"
       with:
         fixup-command: "go mod tidy"
     - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0


### PR DESCRIPTION
runtime-operator -> wash