### PR TITLE
fix: Runtime Operator Resiliency Pass

### DIFF
--- a/runtime-operator/api/condition/conditioned_reconciler_test.go
+++ b/runtime-operator/api/condition/conditioned_reconciler_test.go
@@ -388,7 +388,8 @@ func TestConditionedReconciler(t *testing.T) {
 			kubeClient := fake.NewClientBuilder().
 				WithInterceptorFuncs(interceptor).
 				WithScheme(scheme).
-				WithObjects(&tc.obj).Build()
+				WithObjects(&tc.obj).
+				WithStatusSubresource(&tc.obj).Build()
 
 			finalizerFunc := func(ctx context.Context, obj *conditionedResource) error {
 				if tc.emitFinalizerError {

--- a/runtime-operator/internal/controller/runtime/host_client.go
+++ b/runtime-operator/internal/controller/runtime/host_client.go
@@ -12,6 +12,8 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
+// HostRoundtripTimeout is the max timeout for host RPC calls.
+// Callers can set lower context timeouts as needed.
 const HostRoundtripTimeout = 1 * time.Minute
 
 func NewWashHostClient(bus wasmbus.Bus, hostID string) *WashHostClient {

--- a/runtime-operator/internal/controller/runtime/host_controller.go
+++ b/runtime-operator/internal/controller/runtime/host_controller.go
@@ -21,6 +21,7 @@ import (
 )
 
 const (
+	hostHeartbeatTimeout  = 5 * time.Second
 	hostReconcileInterval = 1 * time.Minute
 )
 
@@ -43,7 +44,7 @@ func (r *HostReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 func (r *HostReconciler) reconcileReporting(ctx context.Context, host *runtimev1alpha1.Host) error {
 	client := NewWashHostClient(r.Bus, host.HostID)
 
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, hostHeartbeatTimeout)
 	defer cancel()
 
 	heartbeat, err := client.Heartbeat(ctx)

--- a/runtime-operator/internal/controller/runtime/workload_deployment_controller.go
+++ b/runtime-operator/internal/controller/runtime/workload_deployment_controller.go
@@ -305,5 +305,16 @@ func resolveArtifacts(ctx context.Context, kubeClient client.Client, namespace s
 		tpl.Spec.Components[i] = comp
 	}
 
+	if tpl.Spec.Service != nil {
+		if strings.HasPrefix(tpl.Spec.Service.Image, "artifact://") {
+			artifactName := strings.TrimPrefix(tpl.Spec.Service.Image, "artifact://")
+			artifact, ok := artifactMap[artifactName]
+			if !ok {
+				return fmt.Errorf("artifact %s not found in deployment spec", artifactName)
+			}
+			tpl.Spec.Service.Image = artifact.Status.ArtifactURL
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
## Status Updates

Using `Patch` instead of `Update`. This reduces sporadic reconcile failures.

## Workload Reconciliation

Start/Status/Stop operations now enforce a NATS request timeout.

## WorkloadReplicaSet Reconciliation

Fixed a bug where Workloads were not being replaced

## WorkloadDeployment Reconciliation

Fixed a bug where Artifacts were not being templated in Service Image