### PR TITLE
chore: washlet action logs

### DIFF
--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -419,11 +419,11 @@ impl ResolvedWorkload {
                     if let Err(e) = instance.wasi_cli_run().call_run(&mut store).await {
                         warn!(err = %e, retries = max_restarts, "service execution failed");
                         if max_restarts == 0 {
-                            info!("max restarts reached, service will not be restarted");
+                            warn!("max restarts reached, service will not be restarted");
                             break;
                         }
                     } else {
-                        info!("service executed successfully");
+                        info!("service exited successfully");
                         break;
                     }
                     max_restarts = max_restarts.saturating_sub(1);

--- a/crates/wash-runtime/src/host/http.rs
+++ b/crates/wash-runtime/src/host/http.rs
@@ -187,10 +187,7 @@ impl Router for DevRouter {
     ) -> anyhow::Result<String> {
         let lock = self.last_workload_id.try_lock()?;
         match &*lock {
-            Some(id) => {
-                tracing::info!(workload_id = %id, "incoming request");
-                Ok(id.clone())
-            }
+            Some(id) => Ok(id.clone()),
             None => anyhow::bail!("no workload available to route request"),
         }
     }
@@ -353,7 +350,7 @@ impl<T: Router> HostHandler for HttpServer<T> {
         *shutdown_tx_clone.write().await = Some(shutdown_tx);
 
         let listener = TcpListener::bind(addr).await?;
-        debug!(addr = ?addr, "HTTP server listening");
+        info!(addr = ?addr, "HTTP server listening");
         // Start the HTTP server, any incoming requests call Host::handle and then it's routed
         // to the workload based on host header.
         let handler = self.router.clone();

--- a/crates/wash-runtime/src/host/mod.rs
+++ b/crates/wash-runtime/src/host/mod.rs
@@ -278,6 +278,30 @@ impl Host {
         &self.id
     }
 
+    /// Get the system hostname for this host.
+    ///
+    /// # Returns
+    /// The host's system hostname string.
+    pub fn hostname(&self) -> &str {
+        &self.hostname
+    }
+
+    /// Get all labels assigned to this host.
+    ///
+    /// # Returns
+    /// A reference to the host's labels map.
+    pub fn labels(&self) -> &HashMap<String, String> {
+        &self.labels
+    }
+
+    /// Get the version of this host.
+    ///
+    /// # Returns
+    /// The host's version string.
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+
     /// Get host config
     ///
     /// # Returns

--- a/crates/wash-runtime/src/oci.rs
+++ b/crates/wash-runtime/src/oci.rs
@@ -42,7 +42,7 @@ use std::{
     path::PathBuf,
     time::Duration,
 };
-use tracing::{debug, info, instrument, warn};
+use tracing::{debug, instrument, warn};
 
 #[allow(deprecated)]
 #[deprecated = "old media type used before Wasm WG standardization"]
@@ -168,7 +168,6 @@ impl CacheManager {
 
     /// Read cached artifact, returning (component_data, digest)
     async fn read_cached(&self, reference: &str) -> Result<(Vec<u8>, String)> {
-        info!(reference = %reference, "reading cached artifact instead of pulling");
         let component_path = self.get_component_path(reference);
         let digest_path = self.get_digest_path(reference);
 
@@ -321,8 +320,6 @@ impl CredentialResolver {
 /// ```
 #[instrument(skip(config), fields(reference = %reference))]
 pub async fn pull_component(reference: &str, config: OciConfig) -> Result<(Vec<u8>, String)> {
-    info!(reference = %reference, "Pulling component");
-
     // Parse OCI reference
     let reference_parsed = Reference::try_from(reference)
         .with_context(|| format!("invalid OCI reference: {reference}"))?;
@@ -411,7 +408,6 @@ pub async fn pull_component(reference: &str, config: OciConfig) -> Result<(Vec<u
             .with_context(|| "failed to cache component")?;
     }
 
-    info!(size = component_data.len(), digest = %digest, "Successfully pulled component");
     Ok((component_data, digest))
 }
 
@@ -463,12 +459,6 @@ pub async fn push_component(
     config: OciConfig,
     annotations: Option<HashMap<String, String>>,
 ) -> Result<String> {
-    info!(
-        reference = %reference,
-        size = component_data.len(),
-        "pushing component"
-    );
-
     // Parse OCI reference
     let reference_parsed = Reference::try_from(reference)
         .with_context(|| format!("invalid OCI reference: {reference}"))?;
@@ -581,7 +571,6 @@ pub async fn push_component(
             .with_context(|| "failed to cache pushed component")?;
     }
 
-    info!(digest = %digest, "successfully pushed component");
     Ok(digest)
 }
 

--- a/crates/wash-runtime/src/washlet/mod.rs
+++ b/crates/wash-runtime/src/washlet/mod.rs
@@ -134,6 +134,14 @@ pub async fn run_cluster_host(
     let host_id = host.id().to_string();
     let host = host.clone();
 
+    info!(
+        host_id=?host_id,
+        friendly_name=?host.friendly_name(),
+        host_name=?host.hostname(),
+        labels=?host.labels(),
+        version=?host.version(),
+        "Host started");
+
     let task = tokio::task::spawn(async move {
         let host_subject = host_subject(host_id.as_ref());
 

--- a/crates/wash-runtime/src/washlet/plugins/wasi_logging.rs
+++ b/crates/wash-runtime/src/washlet/plugins/wasi_logging.rs
@@ -153,13 +153,6 @@ impl HostPlugin for TracingLogging {
             |ctx| ctx,
         )?;
 
-        tracing::info!(
-            "TracingLoggingPlugin bound to component {} of workload {} in namespace {}",
-            component.id(),
-            component.workload_name(),
-            component.workload_namespace()
-        );
-
         self.components.write().await.insert(
             component.id().to_string(),
             ComponentInfo {

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -93,7 +93,6 @@ impl CliCommand for HostCommand {
         }
 
         if let Some(addr) = self.http_addr {
-            tracing::info!(addr = ?addr, "Starting HTTP server for components");
             let http_router = wash_runtime::host::http::DynamicRouter::default();
             cluster_host_builder = cluster_host_builder.with_http_handler(Arc::new(
                 wash_runtime::host::http::HttpServer::new(http_router, addr),

--- a/src/main.rs
+++ b/src/main.rs
@@ -349,6 +349,12 @@ fn initialize_tracing(
         // Enable dynamic filtering from `RUST_LOG`, fallback to "info", but always set wasm_pkg_client=error
         let env_filter = EnvFilter::try_from_default_env()
             .unwrap_or_else(|_| EnvFilter::new(log_level.as_str()))
+            // async_nats prints out on connect
+            .add_directive(
+                "async_nats=error"
+                    .parse()
+                    .expect("failed to parse async_nats directive"),
+            )
             // wasm_pkg_client/core are a little verbose so we set them to error level in non-verbose mode
             .add_directive(
                 "wasm_pkg_client=error"


### PR DESCRIPTION
Silencing `async_nats` & component pulls.

New log messages:
- host start
- http server start/stop
- workload start
- workload stop
- workload status (debug only)

Example session starting / stopping a few workloads
```
2025-11-26T18:48:32.222306Z  INFO Starting HTTP server for components addr=0.0.0.0:8000
2025-11-26T18:48:32.238675Z  INFO Host started host_id="4d988653-8d6f-4ef2-915f-cb09dd2c864b" friendly_name="rough-agreement-0608" host_name="lucas-MacBook-Pro" labels={"hostgroup": "default"} version="0.2.0"
2025-11-26T18:49:18.667763Z  INFO Starting workload worload_id="665b90d3-dea2-418a-aa31-ba4e9a7a6671" namespace="default" name="hello-7bf6894d77-558cb4fff8"
2025-11-26T18:49:18.837131Z  INFO Stopping workload worload_id="665b90d3-dea2-418a-aa31-ba4e9a7a6671"
2025-11-26T18:49:20.167167Z  INFO Starting workload worload_id="c0856f00-cc29-4071-b790-f823cc348d83" namespace="default" name="hello-865d7c48-8c88cd9b6"
2025-11-26T18:49:37.384310Z  INFO Stopping workload worload_id="c0856f00-cc29-4071-b790-f823cc348d83"
2025-11-26T18:49:48.055129Z  INFO Starting workload worload_id="f88b3880-7b62-44c0-b650-46c5f88e79e7" namespace="default" name="hello-74dcf9c5f8-7496bb77c8"
2025-11-26T18:49:55.753467Z  INFO Stopping workload worload_id="f88b3880-7b62-44c0-b650-46c5f88e79e7"
```