### PR TITLE
Fix Helm chart to respect nats.enabled flag

### DIFF
--- a/charts/runtime-operator/templates/nats/deployment.yaml
+++ b/charts/runtime-operator/templates/nats/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.nats.enabled }}
 {{- $registry := .Values.nats.image.registry | default .Values.global.image.registry | default "docker.io" -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -36,3 +37,4 @@ spec:
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       terminationGracePeriodSeconds: 0
+{{- end }}

--- a/charts/runtime-operator/templates/nats/service.yaml
+++ b/charts/runtime-operator/templates/nats/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.nats.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,3 +16,4 @@ spec:
       targetPort: nats
       protocol: TCP
       name: nats
+{{- end }}

--- a/charts/runtime-operator/templates/nats/serviceaccount.yaml
+++ b/charts/runtime-operator/templates/nats/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.nats.serviceAccount.create -}}
+{{- if and .Values.nats.enabled .Values.nats.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
I have my own nats cluster and I tried to disable nats in the chart but it would still deploy a nats cluster.

These changes were made by copilot so I understand if  you don't want that.

NATS resources (Deployment, Service, ServiceAccount) were deployed regardless of the `nats.enabled` setting in values.yaml.

### Changes
- Wrap `templates/nats/deployment.yaml` with `{{- if .Values.nats.enabled }}`
- Wrap `templates/nats/service.yaml` with `{{- if .Values.nats.enabled }}`
- Update `templates/nats/serviceaccount.yaml` condition to check both `nats.enabled` and `serviceAccount.create`

### Verification
```bash
# With nats.enabled=false, no NATS resources rendered
helm template test . --set nats.enabled=false | grep "name: nats"
# (empty output)

# Default behavior unchanged
helm template test . | grep "name: nats"
# name: nats (deployment, service, serviceaccount all present)
```