### PR TITLE
Add NATS TLS configuration options to wash host and runtime-operator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,6 @@ version = "0.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f834a80c3ab6109b9c8f5ca6661a578cf31e088e831b6ce07c6b23cca04f6742"
 dependencies = [
- "aws-lc-rs",
  "base64 0.22.1",
  "bytes",
  "futures-util",
@@ -258,6 +257,7 @@ dependencies = [
  "portable-atomic",
  "rand 0.8.5",
  "regex",
+ "ring",
  "rustls-native-certs 0.7.3",
  "rustls-pemfile",
  "rustls-webpki 0.102.8",
@@ -375,30 +375,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879b6c89592deb404ba4dc0ae6b58ffd1795c78991cbb5b8bc441c48a070440d"
-dependencies = [
- "aws-lc-sys",
- "untrusted 0.7.1",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "107a4e9d9cab9963e04e84bb8dee0e25f2a987f9a8bad5ed054abd439caa8f8c"
-dependencies = [
- "bindgen",
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "axum"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,26 +468,6 @@ name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
-
-[[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags 2.9.3",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 2.1.1",
- "shlex",
- "syn",
-]
 
 [[package]]
 name = "bit-set"
@@ -741,15 +697,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,17 +730,6 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -854,15 +790,6 @@ name = "clap_lex"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
-
-[[package]]
-name = "cmake"
-version = "0.1.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "cobs"
@@ -1536,12 +1463,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1880,12 +1801,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2106,12 +2021,6 @@ dependencies = [
  "log",
  "xml-rs",
 ]
-
-[[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "glow"
@@ -4663,7 +4572,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.16",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -4772,7 +4681,6 @@ version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -4832,10 +4740,9 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -4844,10 +4751,9 @@ version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -5681,7 +5587,6 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
 dependencies = [
- "aws-lc-rs",
  "base64 0.22.1",
  "bytes",
  "futures-core",
@@ -5689,6 +5594,7 @@ dependencies = [
  "http",
  "httparse",
  "rand 0.8.5",
+ "ring",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -6030,12 +5936,6 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ pbjson-types = { version = "0.8.0", default-features = false }
 pbjson-build = { version = "0.8.0", default-features = false }
 prost = { version = "0.14", default-features = false }
 reqwest = { version = "0.12.20", default-features = false, features = ["json", "rustls-tls"] }
-rustls = { version = "0.23", default-features = false, features = ["std", "tls12"] }
+rustls = { version = "0.23", default-features = false, features = ["std", "tls12", "ring"] }
 rustls-pemfile = { version = "2.2", default-features = false, features = ["std"] }
 schemars = { version = "0.8", default-features = false }
 git2 = { version = "0.19", default-features = false }

--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -23,7 +23,7 @@ wasi-webgpu = ["dep:wasi-webgpu-wasmtime", "dep:wasi-graphics-context-wasmtime"]
 
 [dependencies]
 anyhow = { workspace = true }
-async-nats = { workspace = true, features = ["aws-lc-rs"] }
+async-nats = { workspace = true, features = ["ring"] }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
@@ -49,7 +49,7 @@ tokio-rustls = { workspace = true }
 tokio-util = { workspace = true, features = ["rt"] }
 tonic = { workspace = true, features = [
     "gzip",
-    "tls-aws-lc",
+    "tls-ring",
     "transport",
     "router",
     "codegen",

--- a/crates/wash-runtime/src/washlet/mod.rs
+++ b/crates/wash-runtime/src/washlet/mod.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -191,14 +192,40 @@ pub async fn run_cluster_host(
     })
 }
 
+/// Configuration options for NATS connections
+#[derive(Debug, Clone, Default)]
+pub struct NatsConnectionOptions {
+    /// Request timeout for NATS operations
+    pub request_timeout: Option<Duration>,
+    /// Path to TLS CA certificate file for NATS connection
+    pub tls_ca: Option<PathBuf>,
+    /// Enable TLS handshake first mode for NATS connection
+    pub tls_first: bool,
+    /// Path to NATS credentials file
+    pub credentials: Option<PathBuf>,
+}
+
 pub async fn connect_nats(
     addr: impl async_nats::ToServerAddrs,
-    request_timeout: Option<Duration>,
+    options: Option<NatsConnectionOptions>,
 ) -> Result<async_nats::Client, anyhow::Error> {
+    let options = options.unwrap_or_default();
     let mut opts = async_nats::ConnectOptions::new();
-    if let Some(timeout) = request_timeout {
+    if let Some(timeout) = options.request_timeout {
         opts = opts.request_timeout(Some(timeout));
-    };
+    }
+    if let Some(tls_ca) = options.tls_ca {
+        opts = opts.add_root_certificates(tls_ca);
+    }
+    if options.tls_first {
+        opts = opts.tls_first();
+    }
+    if let Some(credentials) = options.credentials {
+        opts = opts
+            .credentials_file(&credentials)
+            .await
+            .context("failed to load NATS credentials")?;
+    }
     opts.connect(addr)
         .await
         .context("failed to connect to NATS")

--- a/crates/wash-runtime/src/washlet/mod.rs
+++ b/crates/wash-runtime/src/washlet/mod.rs
@@ -215,12 +215,22 @@ pub async fn connect_nats(
         opts = opts.request_timeout(Some(timeout));
     }
     if let Some(tls_ca) = options.tls_ca {
+        anyhow::ensure!(
+            tls_ca.exists(),
+            "NATS TLS CA certificate file does not exist: {}",
+            tls_ca.display()
+        );
         opts = opts.add_root_certificates(tls_ca);
     }
     if options.tls_first {
         opts = opts.tls_first();
     }
     if let Some(credentials) = options.credentials {
+        anyhow::ensure!(
+            credentials.exists(),
+            "NATS credentials file does not exist: {}",
+            credentials.display()
+        );
         opts = opts
             .credentials_file(&credentials)
             .await

--- a/crates/wash-runtime/src/washlet/mod.rs
+++ b/crates/wash-runtime/src/washlet/mod.rs
@@ -648,8 +648,6 @@ impl From<crate::types::WorkloadStatus> for types::v2::WorkloadStatus {
 
 #[cfg(test)]
 mod tests {
-    use crate::host;
-
     use super::*;
 
     #[tokio::test]

--- a/runtime-operator/.gitignore
+++ b/runtime-operator/.gitignore
@@ -35,3 +35,6 @@ tmp/**
 
 # Junk
 .DS_Store
+
+# Compiled binary
+/main

--- a/runtime-operator/cmd/main.go
+++ b/runtime-operator/cmd/main.go
@@ -61,6 +61,8 @@ func main() {
 		metricsAddr                 string
 		natsUrl                     string
 		natsCreds                   string
+		natsTlsCa                   string
+		natsTlsFirst                bool
 		enableLeaderElection        bool
 		probeAddr                   string
 		secureMetrics               bool
@@ -76,6 +78,8 @@ func main() {
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8082", "The address the probe endpoint binds to.")
 	flag.StringVar(&natsCreds, "nats-creds", "", "Path to NATS credentials file.")
 	flag.StringVar(&natsUrl, "nats-url", wasmbus.NatsDefaultURL, "The nats server address to connect to.")
+	flag.StringVar(&natsTlsCa, "nats-tls-ca", "", "Path to TLS CA certificate file for NATS connection.")
+	flag.BoolVar(&natsTlsFirst, "nats-tls-first", false, "Enable TLS handshake first mode for NATS connection.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -123,6 +127,14 @@ func main() {
 
 	if natsCreds != "" {
 		operatorCfg.NatsOptions = append(operatorCfg.NatsOptions, nats.UserCredentials(natsCreds))
+	}
+
+	if natsTlsCa != "" {
+		operatorCfg.NatsOptions = append(operatorCfg.NatsOptions, nats.RootCAs(natsTlsCa))
+	}
+
+	if natsTlsFirst {
+		operatorCfg.NatsOptions = append(operatorCfg.NatsOptions, nats.TLSHandshakeFirst())
 	}
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled

--- a/runtime-operator/cmd/main.go
+++ b/runtime-operator/cmd/main.go
@@ -126,10 +126,18 @@ func main() {
 	}
 
 	if natsCreds != "" {
+		if _, err := os.Stat(natsCreds); os.IsNotExist(err) {
+			setupLog.Error(err, "NATS credentials file does not exist", "path", natsCreds)
+			os.Exit(1)
+		}
 		operatorCfg.NatsOptions = append(operatorCfg.NatsOptions, nats.UserCredentials(natsCreds))
 	}
 
 	if natsTlsCa != "" {
+		if _, err := os.Stat(natsTlsCa); os.IsNotExist(err) {
+			setupLog.Error(err, "NATS TLS CA certificate file does not exist", "path", natsTlsCa)
+			os.Exit(1)
+		}
 		operatorCfg.NatsOptions = append(operatorCfg.NatsOptions, nats.RootCAs(natsTlsCa))
 	}
 


### PR DESCRIPTION
I have a nats cluster but it uses tls-first and a custom CA, with these changes the host and operator can communicate with it.

This was done by copilot, so I understand if you don't like these changes.

- [x] Understand the codebase and identify affected areas
- [x] Add `--nats-tls-ca` and `--nats-tls-first` flags to runtime-operator (Go)
- [x] Add `--nats-tls-ca`, `--nats-tls-first`, and `--nats-creds` flags to `wash host` command (Rust)
- [x] Update the `connect_nats` function in washlet to support TLS options
- [x] Build and test the changes
- [x] Run code review and address feedback
- [x] Fix CryptoProvider panic by using ring consistently across all TLS dependencies