### PR TITLE
chore(runtime-operator): VolumeMounts & read-only volumes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6249,7 +6249,7 @@ dependencies = [
 
 [[package]]
 name = "wash"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 categories = ["wasm", "command-line-utilities"]
 description = "The Wasm Shell (wash) for developing and publishing Wasm components"
 keywords = ["webassembly", "wasm", "component", "wash", "cli"]

--- a/charts/runtime-operator/templates/crds/runtime.wasmcloud.dev_workloaddeployments.yaml
+++ b/charts/runtime-operator/templates/crds/runtime.wasmcloud.dev_workloaddeployments.yaml
@@ -200,6 +200,10 @@ spec:
                                           Volume defined in the WorkloadSpec.Volumes
                                           field.
                                         type: string
+                                      readOnly:
+                                        description: ReadOnly indicates whether the
+                                          volume should be mounted as read-only.
+                                        type: boolean
                                     required:
                                     - mountPath
                                     - name
@@ -399,6 +403,10 @@ spec:
                                       description: Name must match the Name of a Volume
                                         defined in the WorkloadSpec.Volumes field.
                                       type: string
+                                    readOnly:
+                                      description: ReadOnly indicates whether the
+                                        volume should be mounted as read-only.
+                                      type: boolean
                                   required:
                                   - mountPath
                                   - name

--- a/charts/runtime-operator/templates/crds/runtime.wasmcloud.dev_workloadreplicasets.yaml
+++ b/charts/runtime-operator/templates/crds/runtime.wasmcloud.dev_workloadreplicasets.yaml
@@ -171,6 +171,10 @@ spec:
                                           Volume defined in the WorkloadSpec.Volumes
                                           field.
                                         type: string
+                                      readOnly:
+                                        description: ReadOnly indicates whether the
+                                          volume should be mounted as read-only.
+                                        type: boolean
                                     required:
                                     - mountPath
                                     - name
@@ -370,6 +374,10 @@ spec:
                                       description: Name must match the Name of a Volume
                                         defined in the WorkloadSpec.Volumes field.
                                       type: string
+                                    readOnly:
+                                      description: ReadOnly indicates whether the
+                                        volume should be mounted as read-only.
+                                      type: boolean
                                   required:
                                   - mountPath
                                   - name

--- a/charts/runtime-operator/templates/crds/runtime.wasmcloud.dev_workloads.yaml
+++ b/charts/runtime-operator/templates/crds/runtime.wasmcloud.dev_workloads.yaml
@@ -158,6 +158,10 @@ spec:
                                 description: Name must match the Name of a Volume
                                   defined in the WorkloadSpec.Volumes field.
                                 type: string
+                              readOnly:
+                                description: ReadOnly indicates whether the volume
+                                  should be mounted as read-only.
+                                type: boolean
                             required:
                             - mountPath
                             - name
@@ -357,6 +361,10 @@ spec:
                               description: Name must match the Name of a Volume defined
                                 in the WorkloadSpec.Volumes field.
                               type: string
+                            readOnly:
+                              description: ReadOnly indicates whether the volume should
+                                be mounted as read-only.
+                              type: boolean
                           required:
                           - mountPath
                           - name

--- a/runtime-operator/api/runtime/v1alpha1/workload_types.go
+++ b/runtime-operator/api/runtime/v1alpha1/workload_types.go
@@ -44,6 +44,9 @@ type VolumeMount struct {
 	// MountPath is the path within the component where the volume should be mounted.
 	// +kubebuilder:validation:Required
 	MountPath string `json:"mountPath"`
+	// ReadOnly indicates whether the volume should be mounted as read-only.
+	// +kubebuilder:validation:Optional
+	ReadOnly bool `json:"readOnly,omitempty"`
 }
 
 type ConfigLayer struct {

--- a/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloaddeployments.yaml
+++ b/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloaddeployments.yaml
@@ -200,6 +200,10 @@ spec:
                                           Volume defined in the WorkloadSpec.Volumes
                                           field.
                                         type: string
+                                      readOnly:
+                                        description: ReadOnly indicates whether the
+                                          volume should be mounted as read-only.
+                                        type: boolean
                                     required:
                                     - mountPath
                                     - name
@@ -399,6 +403,10 @@ spec:
                                       description: Name must match the Name of a Volume
                                         defined in the WorkloadSpec.Volumes field.
                                       type: string
+                                    readOnly:
+                                      description: ReadOnly indicates whether the
+                                        volume should be mounted as read-only.
+                                      type: boolean
                                   required:
                                   - mountPath
                                   - name

--- a/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloadreplicasets.yaml
+++ b/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloadreplicasets.yaml
@@ -171,6 +171,10 @@ spec:
                                           Volume defined in the WorkloadSpec.Volumes
                                           field.
                                         type: string
+                                      readOnly:
+                                        description: ReadOnly indicates whether the
+                                          volume should be mounted as read-only.
+                                        type: boolean
                                     required:
                                     - mountPath
                                     - name
@@ -370,6 +374,10 @@ spec:
                                       description: Name must match the Name of a Volume
                                         defined in the WorkloadSpec.Volumes field.
                                       type: string
+                                    readOnly:
+                                      description: ReadOnly indicates whether the
+                                        volume should be mounted as read-only.
+                                      type: boolean
                                   required:
                                   - mountPath
                                   - name

--- a/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloads.yaml
+++ b/runtime-operator/config/crd/bases/runtime.wasmcloud.dev_workloads.yaml
@@ -158,6 +158,10 @@ spec:
                                 description: Name must match the Name of a Volume
                                   defined in the WorkloadSpec.Volumes field.
                                 type: string
+                              readOnly:
+                                description: ReadOnly indicates whether the volume
+                                  should be mounted as read-only.
+                                type: boolean
                             required:
                             - mountPath
                             - name
@@ -357,6 +361,10 @@ spec:
                               description: Name must match the Name of a Volume defined
                                 in the WorkloadSpec.Volumes field.
                               type: string
+                            readOnly:
+                              description: ReadOnly indicates whether the volume should
+                                be mounted as read-only.
+                              type: boolean
                           required:
                           - mountPath
                           - name

--- a/runtime-operator/internal/controller/runtime/workload_controller.go
+++ b/runtime-operator/internal/controller/runtime/workload_controller.go
@@ -127,7 +127,7 @@ func (r *WorkloadReconciler) reconcilePlacement(ctx context.Context, workload *r
 		return nil
 	}
 
-	volumes := make([]*runtimev2.Volume, len(workload.Spec.Volumes))
+	volumes := make([]*runtimev2.Volume, 0, len(workload.Spec.Volumes))
 	for _, v := range workload.Spec.Volumes {
 		vol := &runtimev2.Volume{
 			Name: v.Name,
@@ -178,6 +178,20 @@ func (r *WorkloadReconciler) reconcilePlacement(ctx context.Context, workload *r
 				}
 				localResources.Environment = localEnvironment
 			}
+
+			if c.LocalResources.VolumeMounts != nil {
+				localResources.VolumeMounts = make([]*runtimev2.VolumeMount, 0, len(c.LocalResources.VolumeMounts))
+				for _, vm := range c.LocalResources.VolumeMounts {
+					volumeMount := &runtimev2.VolumeMount{
+						Name:      vm.Name,
+						MountPath: vm.MountPath,
+					}
+					if vm.ReadOnly {
+						volumeMount.ReadOnly = true
+					}
+					localResources.VolumeMounts = append(localResources.VolumeMounts, volumeMount)
+				}
+			}
 		}
 
 		var imagePullSecret *runtimev2.ImagePullSecret = nil
@@ -212,6 +226,20 @@ func (r *WorkloadReconciler) reconcilePlacement(ctx context.Context, workload *r
 					return fmt.Errorf("materializing local resources config for service: %w", err)
 				}
 				localResources.Environment = localEnvironment
+			}
+
+			if s.LocalResources.VolumeMounts != nil {
+				localResources.VolumeMounts = make([]*runtimev2.VolumeMount, 0, len(s.LocalResources.VolumeMounts))
+				for _, vm := range s.LocalResources.VolumeMounts {
+					volumeMount := &runtimev2.VolumeMount{
+						Name:      vm.Name,
+						MountPath: vm.MountPath,
+					}
+					if vm.ReadOnly {
+						volumeMount.ReadOnly = true
+					}
+					localResources.VolumeMounts = append(localResources.VolumeMounts, volumeMount)
+				}
 			}
 		}
 


### PR DESCRIPTION
## Operator

- Add `readOnly` to Components & Service VolumeMount.
- (missing) Properly thread VolumeMounts for Components & Service.
- (bug) Properly initialize `volumes` slice, which was being sent down to hosts with 1 extra  entry  (blank)

Updates CRD definitions under chart too.

## wash

Bump version to rc4

