### PR TITLE
fix: wash 2 rc4 CI fixes

### DIFF
--- a/.github/workflows/wash.yml
+++ b/.github/workflows/wash.yml
@@ -154,7 +154,7 @@ jobs:
           - target: x86_64-apple-darwin
             buildCommand: cargo build
             artifact: wash-x86_64-apple-darwin
-            runner: macos-latest
+            runner: macos-15-intel
             bin: wash
           - target: aarch64-apple-darwin
             buildCommand: cargo build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6249,7 +6249,7 @@ dependencies = [
 
 [[package]]
 name = "wash"
-version = "1.0.0-rc.4"
+version = "2.0.0-rc.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ USER nonroot
 # dependencies cache
 COPY Cargo.toml Cargo.lock rust-toolchain.toml rustfmt.toml ./
 COPY --parents ./crates/**/Cargo.toml ./
-RUN cargo fetch
+RUN cargo fetch --locked
 
 # copy source code
 COPY . .


### PR DESCRIPTION
macos: locks intel build to macos15 ( deprecation incoming )
making sure cargo fetch doesn't try to update lockfiles