### PR TITLE
chore: Prepare 2.0.0-rc5

### DIFF
--- a/.github/actions/helm-publish/action.yaml
+++ b/.github/actions/helm-publish/action.yaml
@@ -22,6 +22,12 @@ inputs:
   registry:
     required: true
     description: The registry to publish the chart to
+  registry-username:
+    required: true
+    description: The username to use for the registry
+  registry-password:
+    required: true
+    description: The password to use for the registry
   registry-namespace:
     required: true
     description: The namespace of the chart to publish
@@ -37,12 +43,9 @@ runs:
       - name: Login to ${{ inputs.registry }}
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
-          registry: ghcr.io
-          username: ricochet
-          password: ${{ secrets.WASMCLOUD_PACKAGES_PAT }}
-          # registry: ${{ inputs.registry }}
-          # username: ${{ github.actor }}
-          # password: ${{ github.token }}
+          registry: ${{ inputs.registry }}
+          username: ${{ inputs.registry-username }}
+          password: ${{ inputs.registry-password }}
 
       - name: Update dependencies with Helmfile
         uses: helmfile/helmfile-action@6f21d94fa797f5dfbc92b9db62c6832ac6639a88 # v2.0.5

--- a/.github/actions/helm-publish/action.yaml
+++ b/.github/actions/helm-publish/action.yaml
@@ -1,0 +1,85 @@
+name: helm-publish
+description: Publish a Helm chart to a registry
+
+inputs:
+  chart-name:
+    required: true
+    description: The name of the chart to publish
+  chart-version:
+    required: false
+    description: The version of the chart to publish
+  chart-app-version:
+    required: false
+    description: The appVersion to set in the chart
+  helm-version:
+    default: "v3.16.4"
+    description: The version of Helm to use
+    required: false
+  helmfile-version:
+    default: "v0.169.2"
+    description: The version of Helmfile to use
+    required: false
+  registry:
+    required: true
+    description: The registry to publish the chart to
+  registry-namespace:
+    required: true
+    description: The namespace of the chart to publish
+
+runs:
+  using: "composite"
+  steps:
+      - name: Set up Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+        with:
+          version: ${{ inputs.helm-version }}
+
+      - name: Login to ${{ inputs.registry }}
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ricochet
+          password: ${{ secrets.WASMCLOUD_PACKAGES_PAT }}
+          # registry: ${{ inputs.registry }}
+          # username: ${{ github.actor }}
+          # password: ${{ github.token }}
+
+      - name: Update dependencies with Helmfile
+        uses: helmfile/helmfile-action@6f21d94fa797f5dfbc92b9db62c6832ac6639a88 # v2.0.5
+        with:
+          helmfile-args: deps
+          helmfile-version: ${{ inputs.helmfile-version }}
+          helmfile-workdirectory: ${{ format('charts/{0}', inputs.chart-name) }}
+          helm-version: ${{ inputs.helm-version }}
+          helm-plugins: >
+            https://github.com/databus23/helm-diff@v3.1.3
+
+      - name: Package
+        if: inputs.chart-app-version != '' && inputs.chart-version != ''
+        shell: bash
+        env:
+          CHART_PATH: ${{ format('charts/{0}', inputs.chart-name)}}
+        run: |
+          helm package --app-version "${{ inputs.chart-app-version }}" --version "${{ inputs.chart-version }}" ${{ env.CHART_PATH }} -d .helm-charts
+
+      - name: Use Git version
+        if: inputs.chart-app-version == '' && inputs.chart-version == ''
+        shell: bash
+        env:
+          CHART_PATH: ${{ format('charts/{0}', inputs.chart-name)}}
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          echo "VERSION=${VERSION}"
+          helm package --app-version "$VERSION" --version "$VERSION" ${{ env.CHART_PATH }} -d .helm-charts
+
+      - name: Publish
+        shell: bash
+        env:
+          CHART_REMOTE: ${{ format('oci://{0}/{1}', inputs.registry, inputs.registry-namespace) }}
+        run: |
+          for chart in .helm-charts/*; do
+            if [ -z "${chart:-}" ]; then
+              break
+            fi
+            helm push "${chart}" "${{ env.CHART_REMOTE }}"
+          done

--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -1,0 +1,58 @@
+name: charts
+on:
+  push:
+    branches:
+      - "main"
+    tags:
+      - "v*"
+  pull_request:
+    paths:
+      - "charts/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: ./.github/actions/setup-go
+      - name: Render
+        run: make helm-render
+
+  canary:
+    if: github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'canary')
+    needs: [test]
+    permissions:
+      contents: write
+      packages: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: ./.github/actions/helm-publish
+        with:
+          chart-name: runtime-operator
+          chart-version: v2-canary
+          chart-app-version: canary
+          registry: ghcr.io
+          registry-namespace: wasmcloud/charts
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [test]
+    permissions:
+      contents: write
+      packages: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: ./.github/actions/helm-publish
+        with:
+          chart-name: runtime-operator
+          registry: ghcr.io
+          registry-namespace: wasmcloud/charts

--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -40,6 +40,8 @@ jobs:
           chart-version: v2-canary
           chart-app-version: canary
           registry: ghcr.io
+          registry-username: ricochet
+          registry-password: ${{ secrets.WASMCLOUD_PACKAGES_PAT }}
           registry-namespace: wasmcloud/charts
 
   release:
@@ -55,4 +57,6 @@ jobs:
         with:
           chart-name: runtime-operator
           registry: ghcr.io
+          registry-username: ricochet
+          registry-password: ${{ secrets.WASMCLOUD_PACKAGES_PAT }}
           registry-namespace: wasmcloud/charts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6249,7 +6249,7 @@ dependencies = [
 
 [[package]]
 name = "wash"
-version = "2.0.0-rc.4"
+version = "2.0.0-rc.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wash"
-version = "2.0.0-rc.4"
+version = "2.0.0-rc.5"
 categories = ["wasm", "command-line-utilities"]
 description = "The Wasm Shell (wash) for developing and publishing Wasm components"
 keywords = ["webassembly", "wasm", "component", "wash", "cli"]

--- a/charts/runtime-operator/helmfile.yaml
+++ b/charts/runtime-operator/helmfile.yaml
@@ -1,0 +1,3 @@
+releases:
+  - name: runtime-operator
+    chart: .

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -68,7 +68,7 @@ runtime:
     registry: ghcr.io
     repository: wasmcloud/wash
     pull_policy: Always
-    tag: "2.0.0-rc.3"
+    tag: "2.0.0-rc.5"
   hostGroups:
     - name: default
       replicas: 1


### PR DESCRIPTION
Release will be done in 3 phases

## Phase 1

Release wash binary & rust crates using `wash-v*` tags. ( `wash-v2.0.0-rc.5` )

### Preparation steps

- Bump  version in `Cargo.toml` and running `cargo check` to update the lockfile.

## Phase 2

Release kubernetes machinery ( operator + gateway + helm chart ) using `v*` tags. ( `v2.0.0-rc.5` )

### Preparation steps

- Set the latest wash host version in `charts/runtime-operator/values.yaml` ( `runtime.image` )
- Make sure CRD definitions are in sync ( `runtime-operator/config/crd/bases` and `charts/runtime-operator/templates/crds` should match )

## Phase 3

Release Golang packages.

Publish the runtime-operator package ( `go.wasmcloud.dev/runtime-operator` ) so others can build custom crds on top of wasmcloud types. Need to figure out which tag go will use for this.