### PR TITLE
chore(docs): update readme quickstart for rc.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ Note: This quickstart requires the [Rust toolchain](https://www.rust-lang.org/to
 3. **Build your component:**
 
    ```bash
-   wash build ./http-hello-world
+   wash -C ./http-hello-world build
    ```
 
 4. **Start a development loop**
 
    ```bash
-   wash dev ./http-hello-world
+   wash -C ./http-hello-world dev
    ```
 
 5. **Keep wash updated:**


### PR DESCRIPTION
Updates readme to reflect `wash -C` usage in rc.6

Wait for rc.6 release to merge.