### PR TITLE
fix: call publish_with_reply when reply_to is present

### DIFF
--- a/crates/wash-runtime/src/washlet/plugins/wasmcloud_messaging.rs
+++ b/crates/wash-runtime/src/washlet/plugins/wasmcloud_messaging.rs
@@ -87,11 +87,23 @@ impl Host for Ctx {
             return Ok(Err("plugin not available".to_string()));
         };
 
-        plugin
-            .client
-            .publish(msg.subject, msg.body.into())
-            .await
-            .context("failed to send message")?;
+        let subject = msg.subject;
+        let reply_to = msg.reply_to;
+
+        if let Some(reply_to) = reply_to {
+            plugin
+                .client
+                .publish_with_reply(subject, reply_to, msg.body.into())
+                .await
+                .context("failed to send message")?;
+        } else {
+            plugin
+                .client
+                .publish(subject, msg.body.into())
+                .await
+                .context("failed to send message")?;
+        }
+
         Ok(Ok(()))
     }
 }

--- a/crates/wash-runtime/src/washlet/plugins/wasmcloud_messaging.rs
+++ b/crates/wash-runtime/src/washlet/plugins/wasmcloud_messaging.rs
@@ -89,7 +89,7 @@ impl Host for Ctx {
 
         let subject = msg.subject;
 
-        if let Some(reply_to) = reply_to {
+        if let Some(reply_to) = msg.reply_to {
             plugin
                 .client
                 .publish_with_reply(subject, reply_to, msg.body.into())

--- a/crates/wash-runtime/src/washlet/plugins/wasmcloud_messaging.rs
+++ b/crates/wash-runtime/src/washlet/plugins/wasmcloud_messaging.rs
@@ -88,7 +88,6 @@ impl Host for Ctx {
         };
 
         let subject = msg.subject;
-        let reply_to = msg.reply_to;
 
         if let Some(reply_to) = reply_to {
             plugin


### PR DESCRIPTION
## Feature or Problem

The messaging plugin's `publish` method was not correctly handling messages with a `reply_to` field. It would always use the standard `publish()` method instead of `publish_with_reply()`, which meant reply-to semantics were not being honored when publishing messages.

## Related Issues

N/A

## Release Information

Next release

## Consumer Impact

This fix improves the correctness of message publishing when reply-to fields are present. Components that rely on reply-to functionality will now work as expected. There is no breaking change or required action for consumers.

## Testing

### Unit Test(s)

No new unit tests added in this PR.

### Acceptance or Integration

No changes to acceptance or integration test suite.

### Manual Verification

Manually verified that:
- Messages with `reply_to` field now correctly use `publish_with_reply()`
- Messages without `reply_to` field continue to use standard `publish()`
- The change works correctly in practice