### PR TITLE
fix: docker / canary builds

### DIFF
--- a/crates/wash-runtime/build.rs
+++ b/crates/wash-runtime/build.rs
@@ -28,7 +28,10 @@ fn build_fixtures_rust(workspace_dir: &Path) -> anyhow::Result<()> {
 
     // Create fixtures directory if it doesn't exist
     if fs::create_dir_all(&fixtures_dir).is_err() {
-        println!("Failed to create fixtures directory at {}. Some tests will fail.", fixtures_dir.display());
+        println!(
+            "Failed to create fixtures directory at {}. Some tests will fail.",
+            fixtures_dir.display()
+        );
         return Ok(());
     }
 

--- a/crates/wash-runtime/build.rs
+++ b/crates/wash-runtime/build.rs
@@ -27,7 +27,10 @@ fn build_fixtures_rust(workspace_dir: &Path) -> anyhow::Result<()> {
     let fixtures_dir = workspace_dir.join("crates/wash-runtime/tests/fixtures");
 
     // Create fixtures directory if it doesn't exist
-    fs::create_dir_all(&fixtures_dir)?;
+    if fs::create_dir_all(&fixtures_dir).is_err() {
+        println!("Failed to create fixtures directory at {}. Some tests will fail.", fixtures_dir.display());
+        return Ok(());
+    }
 
     if !examples_dir.exists() {
         println!("No examples dir found at {}", examples_dir.display());


### PR DESCRIPTION
side effect since fixtures have been git-ignored.
cargo build tries creating files on a read-only docker context, which always fails.