### PR TITLE
fix: prevent invalid component instance reuse across chained invocations

### DIFF
--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -598,9 +598,13 @@ impl ResolvedWorkload {
         let ty = component.component_type();
         let imports: Vec<_> = ty.imports(component.engine()).collect();
 
-        // TODO: some kind of shared import_name -> component registry. need to remove when new store
-        // store id, instance, import_name. That will keep the instance properly unique
-        let instance: Arc<RwLock<Option<(String, Instance)>>> = Arc::default();
+        // Cache instances per exporter component per store. This ensures that all interfaces
+        // from the same exporting component share the same instance, which is required for
+        // resources to work correctly across interface boundaries.
+        // Key: exporter_component_id, Value: (store_id, instance)
+        let component_instance_cache: Arc<RwLock<HashMap<Arc<str>, (String, Instance)>>> =
+            Arc::default();
+
         for (import_name, import_item) in imports.into_iter() {
             match import_item {
                 ComponentItem::ComponentInstance(import_instance_ty) => {
@@ -640,6 +644,12 @@ impl ResolvedWorkload {
                     let pre = plugin_component
                         .pre_instantiate()
                         .context("failed to pre-instantiate during component linking")?;
+
+                    // Get the exporter component ID to use as the cache key
+                    let exporter_component_id: Arc<str> = interface_map
+                        .get(import_name)
+                        .cloned()
+                        .unwrap_or_else(|| Arc::from("unknown"));
 
                     let mut linker_instance = match linker.instance(import_name) {
                         Ok(i) => i,
@@ -681,34 +691,66 @@ impl ResolvedWorkload {
                                 let import_name: Arc<str> = import_name.into();
                                 let export_name: Arc<str> = export_name.into();
                                 let pre = pre.clone();
-                                let instance = instance.clone();
+                                let instance_cache = component_instance_cache.clone();
+                                let exporter_id = exporter_component_id.clone();
                                 linker_instance
                                     .func_new_async(
                                         &export_name.clone(),
                                         move |mut store, params, results| {
-                                            // TODO(#103): some kind of store data hashing mechanism
-                                            // to detect a diff store to drop the old one
                                             let import_name = import_name.clone();
                                             let export_name = export_name.clone();
                                             let pre = pre.clone();
-                                            let instance = instance.clone();
+                                            let instance_cache = instance_cache.clone();
+                                            let exporter_id = exporter_id.clone();
                                             Box::new(async move {
-                                                let existing_instance = instance.read().await;
-                                                let store_id = store.data().id.clone();
-                                                let instance = if let Some((id, instance)) =
-                                                    existing_instance.clone()
-                                                    && id == store_id
-                                                {
-                                                    drop(existing_instance);
-                                                    instance
-                                                } else {
-                                                    // Likely unnecessary, but explicit drop of the read lock
-                                                    let new_instance =
-                                                        pre.instantiate_async(&mut store).await?;
-                                                    drop(existing_instance);
-                                                    *instance.write().await =
-                                                        Some((store_id, new_instance));
-                                                    new_instance
+                                                // Get the store ID to check if we can reuse a cached instance
+                                                let store_id =
+                                                    store.data().id.clone();
+
+                                                // Check if we have a cached instance for this exporter component and store
+                                                let instance = {
+                                                    let cache = instance_cache.read().await;
+                                                    if let Some((cached_store_id, cached_instance)) =
+                                                        cache.get(&exporter_id)
+                                                    {
+                                                        if cached_store_id == &store_id {
+                                                            trace!(
+                                                                name = %import_name,
+                                                                fn_name = %export_name,
+                                                                exporter = %exporter_id,
+                                                                "reusing cached instance for store"
+                                                            );
+                                                            *cached_instance
+                                                        } else {
+                                                            drop(cache);
+                                                            // Different store - create new instance and cache it
+                                                            trace!(
+                                                                name = %import_name,
+                                                                fn_name = %export_name,
+                                                                exporter = %exporter_id,
+                                                                "creating new instance (store changed)"
+                                                            );
+                                                            let new_instance =
+                                                                pre.instantiate_async(&mut store).await?;
+                                                            instance_cache.write().await
+                                                                .insert(exporter_id, (store_id, new_instance));
+                                                            new_instance
+                                                        }
+                                                    } else {
+                                                        drop(cache);
+                                                        // No cached instance for this exporter - create one
+                                                        trace!(
+                                                            name = %import_name,
+                                                            fn_name = %export_name,
+                                                            exporter = %exporter_id,
+                                                            "creating new instance (no cache)"
+                                                        );
+                                                        let new_instance =
+                                                            pre.instantiate_async(&mut store).await?;
+                                                        instance_cache.write().await
+                                                            .insert(exporter_id, (store_id, new_instance));
+                                                        new_instance
+                                                    }
                                                 };
 
                                                 let func = instance


### PR DESCRIPTION
## Feature or Problem

This PR fixes a correctness issue where component instances were incorrectly reused across chained invocations.

In multi-component execution flows (e.g. A → B → C → B), wasmCloud previously captured a `ComponentExportIndex` at link time and attempted to reuse the same component instance on subsequent invocations. This caused `get_func` to fail with `function not found`, even though the export existed and was successfully invoked earlier.

```rust
let func = instance
    .get_func(&mut store, func_idx)
    .context("function not found")?;
```

This change introduces a scoped instance cache keyed by exporter component ID and store ID, ensuring component instances are only reused when it is safe to do so. When the store changes or no cached instance exists for a given exporter, a fresh instance is created.

This avoids stale instance reuse and eliminates silent runtime failures when the same component is invoked more than once in a chained, multi-component execution flow.

Example failure (logs)

```text
hostgroup-default-667c74c7f4-l8dwj host 2025-12-18T16:38:21.044143Z  INFO lifting results name=betty-blocks:data-api/data-api fn_name=request results_buf=[Result(Ok(Some(String("{\"data\":{\"onePokemon\":{\"id\":33,\"name\":\"test\"}}}"))))]
hostgroup-default-667c74c7f4-l8dwj host 2025-12-18T16:38:21.044166Z  INFO invoked dynamic export name=betty-blocks:data-api/data-api fn_name=request results=[Result(Ok(Some(String("{\"data\":{\"onePokemon\":{\"id\":33,\"name\":\"test\"}}}"))))]
hostgroup-default-667c74c7f4-l8dwj host 2025-12-18T16:38:21.044208Z  INFO lifting results name=betty-blocks:crud/crud fn_name=create results_buf=[Result(Ok(Some(String("{\"id\":33,\"name\":\"test\"}"))))]
hostgroup-default-667c74c7f4-l8dwj host 2025-12-18T16:38:21.044213Z  INFO invoked dynamic export name=betty-blocks:crud/crud fn_name=create results=[Result(Ok(Some(String("{\"id\":33,\"name\":\"test\"}"))))]
hostgroup-default-667c74c7f4-l8dwj host 2025-12-18T16:38:21.044233Z  INFO lifting results name=betty-blocks:create/create@0.1.0 fn_name=create results_buf=[Result(Ok(Some(String("{\"id\":33,\"name\":\"test\"}"))))]
hostgroup-default-667c74c7f4-l8dwj host 2025-12-18T16:38:21.044237Z  INFO invoked dynamic export name=betty-blocks:create/create@0.1.0 fn_name=create results=[Result(Ok(Some(String("{\"id\":33,\"name\":\"test\"}"))))]
hostgroup-default-667c74c7f4-l8dwj host 2025-12-18T16:38:21.044686Z  INFO Calling this export name: update
hostgroup-default-667c74c7f4-l8dwj host 2025-12-18T16:38:21.044692Z  INFO Into the new box: update
hostgroup-default-667c74c7f4-l8dwj host 2025-12-18T16:38:21.044695Z  INFO Before creating the instance: update
hostgroup-default-667c74c7f4-l8dwj host 2025-12-18T16:38:21.044697Z  INFO Dropping existing instance: update
hostgroup-default-667c74c7f4-l8dwj host 2025-12-18T16:38:21.044700Z  INFO Starting by getting the function from the instance: update
hostgroup-default-667c74c7f4-l8dwj host 2025-12-18T16:38:21.044703Z  INFO Exported components: [("betty-blocks:update/update@0.1.0", ComponentInstance(ComponentInstance(Handle { index: TypeComponentInstanceIndex(12) })))]
hostgroup-default-667c74c7f4-l8dwj host 2025-12-18T16:38:21.044712Z  INFO Imported components: [("betty-blocks:data-api/data-api", ComponentInstance(ComponentInstance(Handle { index: TypeComponentInstanceIndex(0) }))), ("betty-blocks:crud/crud",
... omitted for clarity
hostgroup-default-667c74c7f4-l8dwj host 2025-12-18T16:38:21.044732Z ERROR Error in gettin func: function not found
```

Fully general instance reuse across stores would likely require upstream changes in Wasmtime. This PR instead scopes instance reuse conservatively to preserve correctness.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
