### PR TITLE
chore: Simplifying dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,6 @@ USER root
 RUN apk --no-cache add protoc protobuf protobuf-dev
 USER nonroot
 
-# dependencies cache
-COPY Cargo.toml Cargo.lock rust-toolchain.toml rustfmt.toml ./
-COPY --parents ./crates/**/Cargo.toml ./
-RUN cargo fetch --locked
-
 # copy source code
 COPY . .
 


### PR DESCRIPTION
Removing dependency cache step as there are interactions with how we setup Cargo.toml workspace.

With the addition of wash-wasi, [we need more files](https://github.com/wasmCloud/wash/actions/runs/20960983950/job/60237862402) to be present during `cargo fetch` ( tests ).

Removing instead of patching as we don't get much cache reuse due to ephemeral github action runners.