### PR TITLE
chore: lint unwrap and expect

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ edition.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[lints]
+workspace = true
+
 [workspace]
 members = [
     "crates/wash-runtime",
@@ -28,6 +31,10 @@ unstable_features = 'warn'
 unused_import_braces = 'warn'
 unused-lifetimes = 'warn'
 unused-macro-rules = 'warn'
+
+[workspace.lints.clippy]
+unwrap_used = 'deny'
+expect_used = 'deny'
 
 [lib]
 name = "wash"

--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -11,6 +11,9 @@ categories = ["wasm"]
 [lib]
 path = "src/lib.rs"
 
+[lints]
+workspace = true
+
 [features]
 default = ["wasi-config", "wasi-logging", "wasi-blobstore", "wasi-keyvalue", "washlet"]
 oci = ["dep:oci-client", "dep:oci-wasm", "dep:docker_credential", "dep:sha2", "dep:wit-component"]

--- a/crates/wash-runtime/build.rs
+++ b/crates/wash-runtime/build.rs
@@ -1,3 +1,6 @@
+// Build scripts commonly use expect() since panics produce clear compile-time errors
+#![allow(clippy::expect_used)]
+
 use std::env;
 use std::fs::{self};
 use std::path::{Path, PathBuf};
@@ -88,7 +91,8 @@ fn build_fixtures_rust(workspace_dir: &Path) -> anyhow::Result<()> {
                         let wasm_path = wasm_entry.path();
 
                         if wasm_path.extension().and_then(|s| s.to_str()) == Some("wasm") {
-                            let dest = fixtures_dir.join(wasm_path.file_name().unwrap());
+                            let dest = fixtures_dir
+                                .join(wasm_path.file_name().expect("wasm file should have a name"));
                             fs::copy(&wasm_path, &dest)?;
                         }
                     }
@@ -163,7 +167,7 @@ fn main() {
     let proto_dir_files = fs::read_dir(proto_dir).expect("failed to list files in `proto_dir`");
     let proto_files: Vec<PathBuf> = proto_dir_files
         .into_iter()
-        .map(|file| file.unwrap().path())
+        .map(|file| file.expect("failed to read proto file").path())
         .collect();
 
     let descriptor_file = out_dir.join("runtime.bin");

--- a/crates/wash-runtime/src/engine/workload.rs
+++ b/crates/wash-runtime/src/engine/workload.rs
@@ -830,7 +830,7 @@ impl ResolvedWorkload {
                                             })
                                         },
                                     )
-                                    .expect("failed to create async func");
+                                    .context("failed to create async func")?;
                             }
                             ComponentItem::Resource(resource_ty) => {
                                 let (item, _idx) = match plugin_component
@@ -1570,15 +1570,12 @@ fn topological_sort_components(
     let mut in_degree: HashMap<Arc<str>, usize> = HashMap::new();
 
     for (component_id, deps) in dependencies {
-        // Initialize entry for this component
-        in_degree.entry(component_id.clone()).or_insert(0);
-
         // Count only dependencies that are part of this workload
         let dep_count = deps
             .iter()
             .filter(|d| dependencies.contains_key(*d))
             .count();
-        *in_degree.get_mut(component_id).unwrap() = dep_count;
+        in_degree.insert(component_id.clone(), dep_count);
     }
 
     // Start with components that have no dependencies (in-degree == 0)
@@ -1627,6 +1624,7 @@ fn topological_sort_components(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use crate::plugin::HostPlugin;

--- a/crates/wash-runtime/src/plugin/wasi_webgpu/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasi_webgpu/mod.rs
@@ -79,11 +79,12 @@ impl wasi_webgpu_wasmtime::MainThreadSpawner for UiThreadSpawner {
 }
 
 impl wasi_webgpu_wasmtime::WasiWebGpuView for SharedCtx {
+    #[allow(clippy::expect_used)] // Trait doesn't return Result; plugin is registered at startup
     fn instance(&self) -> Arc<wasi_webgpu_wasmtime::reexports::wgpu_core::global::Global> {
         let plugin = self
             .active_ctx
             .get_plugin::<WebGpu>(WASI_WEBGPU_ID)
-            .unwrap();
+            .expect("WebGpu plugin should be registered");
         Arc::clone(&plugin.gpu)
     }
 

--- a/crates/wash-runtime/src/wit.rs
+++ b/crates/wash-runtime/src/wit.rs
@@ -288,6 +288,7 @@ impl From<String> for WitInterface {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use std::collections::HashSet;

--- a/crates/wash/src/cli/update.rs
+++ b/crates/wash/src/cli/update.rs
@@ -312,7 +312,11 @@ impl UpdateCommand {
 
         // Sort by version (newest first) and return the best match
         suitable_releases.sort_by(|a, b| b.0.cmp(&a.0));
-        Ok(suitable_releases.into_iter().next().unwrap().1)
+        suitable_releases
+            .into_iter()
+            .next()
+            .map(|(_, release)| release)
+            .ok_or_else(|| anyhow::anyhow!("No suitable updates found"))
     }
 
     /// Fetch the latest release from the configured repository with authentication

--- a/crates/wash/src/cli/wit.rs
+++ b/crates/wash/src/cli/wit.rs
@@ -231,7 +231,9 @@ async fn find_world_wit_file(wit_dir: &std::path::Path) -> Result<std::path::Pat
                         if trimmed.contains('{') {
                             debug!(
                                 "Found world definition in {}",
-                                path.file_name().unwrap().to_string_lossy()
+                                path.file_name()
+                                    .map(|n| n.to_string_lossy())
+                                    .unwrap_or_default()
                             );
                             return Ok(path);
                         }
@@ -239,7 +241,9 @@ async fn find_world_wit_file(wit_dir: &std::path::Path) -> Result<std::path::Pat
                         // Opening brace on next line after world keyword
                         debug!(
                             "Found world definition in {}",
-                            path.file_name().unwrap().to_string_lossy()
+                            path.file_name()
+                                .map(|n| n.to_string_lossy())
+                                .unwrap_or_default()
                         );
                         return Ok(path);
                     } else if found_world_keyword
@@ -825,6 +829,7 @@ async fn handle_build(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use std::fs;

--- a/crates/wash/src/plugin/mod.rs
+++ b/crates/wash/src/plugin/mod.rs
@@ -493,11 +493,10 @@ pub async fn install_plugin(
     let component_data =
         if options.source.starts_with("file://") || Path::new(&options.source).exists() {
             // Load from file
-            let file_path = if options.source.starts_with("file://") {
-                options.source.strip_prefix("file://").unwrap()
-            } else {
-                &options.source
-            };
+            let file_path = options
+                .source
+                .strip_prefix("file://")
+                .unwrap_or(&options.source);
 
             debug!(path = %file_path, "loading plugin from file");
             tokio::fs::read(file_path)

--- a/crates/wash/src/plugin/runner.rs
+++ b/crates/wash/src/plugin/runner.rs
@@ -110,8 +110,12 @@ impl<'a> crate::plugin::bindings::wasmcloud::wash::types::HostContext for Active
 }
 
 impl<'a> crate::plugin::bindings::wasmcloud::wash::types::HostProjectConfig for ActiveCtx<'a> {
+    #[allow(clippy::expect_used)] // Trait returns String; resource guaranteed to exist by contract
     async fn version(&mut self, ctx: Resource<ProjectConfig>) -> String {
-        let c = self.table.get(&ctx).unwrap();
+        let c = self
+            .table
+            .get(&ctx)
+            .expect("project config resource should exist in table");
         c.version.clone()
     }
 

--- a/crates/wash/src/wit.rs
+++ b/crates/wash/src/wit.rs
@@ -573,6 +573,7 @@ pub async fn load_lock_file(project_dir: impl AsRef<Path>) -> Result<LockFile> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use std::collections::HashMap;

--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -1,4 +1,6 @@
 #![allow(clippy::all)]
+#![allow(clippy::unwrap_used)] // wasmtime-wasi fork uses unwrap() patterns from upstream
+#![allow(clippy::expect_used)] // wasmtime-wasi fork uses expect() patterns from upstream
 #![allow(dead_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -413,25 +413,14 @@ fn initialize_tracing(
         (Box::new(std::io::stdout()), Box::new(std::io::stderr()))
     } else {
         // Enable dynamic filtering from `RUST_LOG`, fallback to "info", but always set wasm_pkg_client=error
+        #[allow(clippy::expect_used)] // Static directive strings are always valid
         let env_filter = EnvFilter::try_from_default_env()
             .unwrap_or_else(|_| EnvFilter::new(log_level.as_str()))
             // async_nats prints out on connect
-            .add_directive(
-                "async_nats=error"
-                    .parse()
-                    .expect("failed to parse async_nats directive"),
-            )
+            .add_directive("async_nats=error".parse().expect("valid directive"))
             // wasm_pkg_client/core are a little verbose so we set them to error level in non-verbose mode
-            .add_directive(
-                "wasm_pkg_client=error"
-                    .parse()
-                    .expect("failed to parse wasm_pkg_client directive"),
-            )
-            .add_directive(
-                "wasm_pkg_core=error"
-                    .parse()
-                    .expect("failed to parse wasm_pkg_core directive"),
-            );
+            .add_directive("wasm_pkg_client=error".parse().expect("valid directive"))
+            .add_directive("wasm_pkg_core=error".parse().expect("valid directive"));
 
         let fmt_layer = tracing_subscriber::fmt::layer()
             .with_writer(std::io::stderr)
@@ -451,6 +440,7 @@ fn initialize_tracing(
 }
 
 /// Helper function to ensure that we're exiting the program consistently and with the correct output format.
+#[allow(clippy::expect_used)] // Panicking on stdout failure during exit is acceptable
 fn exit_with_output(stdout: &mut impl std::io::Write, output: CommandOutput) -> ! {
     let (message, success) = output.render();
     writeln!(stdout, "{message}").expect("failed to write output to stdout");


### PR DESCRIPTION
Summary:
- Added [lints] workspace = true to inherit workspace lints
- Added [workspace.lints.clippy] with unwrap_used = 'deny' and expect_used = 'deny'
- Allows in build.rs where it is valid to end execution on failure. 
- Allows in tests for convenience.
- crates/wasi/src/lib.rs - crate-level allows for unwrap_used and expect_used (wasmtime-wasi fork)                                                                                        

Code Changes          
```text                                                                                                                                                                          
┌────────────────────┬────────────────────────────────────┬──────────────────────────────────────────┐                                                                                        
│        File        │               Change               │                 Approach                 │                                                                                        
├────────────────────┼────────────────────────────────────┼──────────────────────────────────────────┤                                                                                        
│ update.rs          │ next().unwrap()                    │ → ok_or_else() (proper error)            │                                                                                        
├────────────────────┼────────────────────────────────────┼──────────────────────────────────────────┤                                                                                        
│ cli/wit.rs         │ file_name().unwrap() in debug logs │ → map().unwrap_or_default()              │                                                                                        
├────────────────────┼────────────────────────────────────┼──────────────────────────────────────────┤                                                                                        
│ plugin/mod.rs      │ strip_prefix().unwrap()            │ → unwrap_or() (simplified)               │                                                                                        
├────────────────────┼────────────────────────────────────┼──────────────────────────────────────────┤                                                                                        
│ plugin/runner.rs   │ table.get().unwrap()               │ → expect() + #[allow] (trait constraint) │                                                                                        
├────────────────────┼────────────────────────────────────┼──────────────────────────────────────────┤                                                                                        
│ main.rs            │ static directive parsing           │ → #[allow] (infallible)                  │                                                                                        
├────────────────────┼────────────────────────────────────┼──────────────────────────────────────────┤                                                                                        
│ main.rs            │ stdout write in exit               │ → #[allow] (exit context)                │                                                                                        
├────────────────────┼────────────────────────────────────┼──────────────────────────────────────────┤                                                                                        
│ http.rs            │ HTTP response building             │ → extracted error_response() helper      │                                                                                        
├────────────────────┼────────────────────────────────────┼──────────────────────────────────────────┤                                                                                        
│ workload.rs:833    │ func_new_async().expect()          │ → .context()? (proper error)             │                                                                                        
├────────────────────┼────────────────────────────────────┼──────────────────────────────────────────┤                                                                                        
│ workload.rs:1581   │ get_mut().expect()                 │ → refactored to use insert()             │                                                                                        
├────────────────────┼────────────────────────────────────┼──────────────────────────────────────────┤                                                                                        
│ wasi_webgpu/mod.rs │ get_plugin().expect()              │ → #[allow] (trait constraint)            │                                                                                        
└────────────────────┴────────────────────────────────────┴──────────────────────────────────────────┘                                                                                        
```