### PR TITLE
chore: log host interfaces

### DIFF
--- a/crates/wash-runtime/src/host/mod.rs
+++ b/crates/wash-runtime/src/host/mod.rs
@@ -48,7 +48,7 @@ use std::time::Duration;
 use anyhow::{Context, bail};
 use names::{Generator, Name};
 use tokio::sync::RwLock;
-use tracing::{debug, trace, warn};
+use tracing::{debug, info, trace, warn};
 use wasmtime::component::Component;
 
 use crate::engine::workload::ResolvedWorkload;
@@ -464,6 +464,22 @@ impl Host {
         );
 
         WitWorld { imports, exports }
+    }
+
+    /// Logs all available host interfaces to the tracing system.
+    pub fn log_interfaces(&self) {
+        let wit_world = self.wit_world();
+
+        // Collect and sort exports for consistent output
+        let mut exports: Vec<_> = wit_world.exports.iter().collect();
+        exports.sort_by(|a, b| (&a.namespace, &a.package).cmp(&(&b.namespace, &b.package)));
+
+        let interfaces: Vec<String> = exports.iter().map(|e| e.to_string()).collect();
+        info!(
+            count = interfaces.len(),
+            interfaces = ?interfaces,
+            "Host provides interfaces"
+        );
     }
 
     /// Returns a three-tuple of (OS architecture, OS name, OS kernel)

--- a/crates/wash-runtime/src/washlet/mod.rs
+++ b/crates/wash-runtime/src/washlet/mod.rs
@@ -140,6 +140,8 @@ pub async fn run_cluster_host(
         version=?host.version(),
         "Host started");
 
+    host.log_interfaces();
+
     let task = tokio::task::spawn(async move {
         let host_subject = host_subject(host_id.as_ref());
 

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -204,6 +204,7 @@ impl CliCommand for DevCommand {
 
         // Build and start the host
         let host = host_builder.build()?.start().await?;
+        host.log_interfaces();
 
         // First run
         let workload = create_workload(&host, &config, wasm_bytes.into()).await?;


### PR DESCRIPTION
The most common challenge for users of the wash host is debugging why a component failed to link to a hostInterface. Often, it's simply that the host doesn't have the plugin and thus doesn't have the interface to link against.

This adds an info log that is always printed on both wash dev and wash host start.

I debated multiple infos vs one single info. I opted for the single info output so that it would be possible for operators in prod to easily get a summarization of their host fleet.

```log
../../target/release/wash dev
2026-01-16T19:37:43.963878Z  INFO starting development session for project path="/Users/bhayes/repos/wasmcloud2/wash/examples/blobby"
2026-01-16T19:37:45.048456Z  INFO building component path="/Users/bhayes/repos/wasmcloud2/wash/examples/blobby"
2026-01-16T19:37:45.048473Z  INFO executing build command command="cargo build --target wasm32-wasip2 --release" component_path="target/wasm32-wasip2/release/blobby.wasm"
    Finished `release` profile [optimized] target(s) in 0.03s
2026-01-16T19:37:45.154869Z  INFO HTTP server listening addr=0.0.0.0:8000
2026-01-16T19:37:45.155053Z  INFO Host provides interfaces count=9 interfaces=["wasi:cli/stderr,exit,terminal-input,terminal-output,environment,terminal-stdin,terminal-stderr,terminal-stdout,stdout,stdin@0.2.0", "wasi:clocks/monotonic-clock,wall-time@0.2.0", "wasi:clocks/monotonic-clock,wall-clock@0.2.0", "wasi:filesystem/preopens,types@0.2.0", "wasi:http/outgoing-handler,types,incoming-handler@0.2.0", "wasi:io/poll,error,streams@0.2.0", "wasi:random/insecure,random,insecure-seed@0.2.0", "wasi:random/random@0.2.0", "wasi:sockets/tcp-create-socket,network,tcp,ip-name-lookup,instance-network,udp,udp-create-socket@0.2.0"]
2026-01-16T19:37:45.210897Z  INFO development session started successfully
2026-01-16T19:37:45.210913Z  INFO listening for HTTP requests address=http://0.0.0.0:8000
2026-01-16T19:37:45.210916Z  INFO watching for file changes (press Ctrl+c to stop)...
```
