### PR TITLE
chore: Release Candidate 6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6347,7 +6347,7 @@ dependencies = [
 
 [[package]]
 name = "wash"
-version = "2.0.0-rc.5"
+version = "2.0.0-rc.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6446,7 +6446,7 @@ dependencies = [
 
 [[package]]
 name = "wash-wasi"
-version = "2.0.0-rc.5"
+version = "2.0.0-rc.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 package.authors = ["The wasmCloud Team"]
 package.edition = "2024"
 package.rust-version = "1.91.0"
-package.version = "2.0.0-rc.5"
+package.version = "2.0.0-rc.6"
 
 [workspace.lints.rust]
 warnings = 'deny' # Treat all warnings as errors
@@ -161,7 +161,7 @@ wasm-pkg-core = { version = "0.10.0", default-features = false }
 wasm-metadata = { version = "0.239.0", default-features = false, features = ["oci"] }
 wasmcloud = { path = "crates/wasmcloud", default-features = false }
 wasmtime = { version = "38", default-features = false }
-wasmtime-wasi = { version = "2.0.0-rc.5", package = "wash-wasi", path = "crates/wasi", default-features = false }
+wasmtime-wasi = { package = "wash-wasi", path = "crates/wasi", default-features = false }
 wasmtime-wasi-io = { version = "38", default-features = false }
 wasmtime-wasi-http = { version = "38", default-features = false }
 which = { version = "6.0.3", default-features = false }

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -68,7 +68,7 @@ runtime:
     registry: ghcr.io
     repository: wasmcloud/wash
     pull_policy: Always
-    tag: "2.0.0-rc.5"
+    tag: "2.0.0-rc.6"
   hostGroups:
     - name: default
       replicas: 1

--- a/runtime-operator/config/samples/blobby.yaml
+++ b/runtime-operator/config/samples/blobby.yaml
@@ -13,7 +13,7 @@ spec:
             - incoming-handler
           config:
             # public dns alias for 127.0.0.1
-            host: blobby.localhost.direct:8000
+            host: blobby.localhost.direct
         - namespace: wasi
           package: blobstore
           version: 0.2.0-draft


### PR DESCRIPTION
- [x] Bump version in Cargo.toml
- [x] Bump version in runtime-operator chart
- [x] Sync CRD definition from runtime-operator to chart
- [x] Validate `runtime-operator/config/samples` work with no extra config
- [ ] ~Remove patch from Cargo.toml~