### PR TITLE
chore: Lock rust version to 1.91

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "stable"
+channel = "1.91.1"
 components = ["clippy", "rustfmt"]
 targets = [
     "wasm32-unknown-unknown",


### PR DESCRIPTION
closes #250 