### PR TITLE
chore(examples): update workloaddeployment.yaml for http-hello-world

### DIFF
--- a/examples/http-hello-world/manifests/workloaddeployment.yaml
+++ b/examples/http-hello-world/manifests/workloaddeployment.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     spec:
       hostSelector:
-        hostgroup: public-ingress
+        hostgroup: default
       components:
         - name: hello-world
           image: ghcr.io/wasmcloud/components/hello-world:0.1.0


### PR DESCRIPTION
Updates manifest to align with hostgroup label [here](https://raw.githubusercontent.com/wasmCloud/wash/refs/heads/main/charts/runtime-operator/values.local.yaml)