### PR TITLE
NATS Client TLS Authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6287,6 +6287,7 @@ dependencies = [
  "pbjson-build 0.8.0",
  "rcgen",
  "reqwest",
+ "rustls 0.23.31",
  "scopeguard",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ figment = { workspace = true, features = ["json", "env", "yaml", "toml"] }
 flate2 = { workspace = true, features = ["rust_backend"] }
 humantime = { workspace = true }
 reqwest = { workspace = true, features = ["json", "rustls-tls"] }
+rustls = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
@@ -141,7 +142,7 @@ pbjson-types = { version = "0.8.0", default-features = false }
 pbjson-build = { version = "0.8.0", default-features = false }
 prost = { version = "0.14", default-features = false }
 reqwest = { version = "0.12.20", default-features = false, features = ["json", "rustls-tls"] }
-rustls = { version = "0.23", default-features = false, features = ["std", "tls12"] }
+rustls = { version = "0.23", default-features = false, features = ["std", "tls12", "aws_lc_rs"] }
 rustls-pemfile = { version = "2.2", default-features = false, features = ["std"] }
 schemars = { version = "0.8", default-features = false }
 git2 = { version = "0.19", default-features = false }

--- a/charts/runtime-operator/templates/certificates.yaml
+++ b/charts/runtime-operator/templates/certificates.yaml
@@ -12,7 +12,7 @@ data:
   tls.crt: {{ $ca.Cert | b64enc }}
   tls.key: {{ $ca.Key | b64enc }}
 ---
-{{ $operatorCert := genSignedCert "wasmcloud-operator" nil nil 365 $ca }}
+{{ $operatorCert := genSignedCert "wasmcloud-operator" nil (list "wasmcloud-operator") 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -26,7 +26,7 @@ data:
   tls.key: {{ $operatorCert.Key | b64enc }}
   ca.crt: {{ $ca.Cert | b64enc }}
 ---
-{{ $runtimeCert := genSignedCert "wasmcloud-runtime" nil nil 365 $ca }}
+{{ $runtimeCert := genSignedCert "wasmcloud-runtime" nil (list "wasmcloud-runtime") 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -40,7 +40,7 @@ data:
   tls.key: {{ $runtimeCert.Key | b64enc }}
   ca.crt: {{ $ca.Cert | b64enc }}
 ---
-{{ $dataCert := genSignedCert "wasmcloud-data" nil nil 365 $ca }}
+{{ $dataCert := genSignedCert "wasmcloud-data" nil (list "wasmcloud-data") 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -54,7 +54,7 @@ data:
   tls.key: {{ $dataCert.Key | b64enc }}
   ca.crt: {{ $ca.Cert | b64enc }}
 ---
-{{ $natsCert := genSignedCert "nats-server" nil nil 365 $ca }}
+{{ $natsCert := genSignedCert "nats" nil (list "nats" "nats.svc.cluster.local") 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/runtime-operator/templates/certificates.yaml
+++ b/charts/runtime-operator/templates/certificates.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.global.certificates.generate }}
+{{ $ca := genCA "wasmcloud CA" 365 }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.global.certificates.caSecretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "runtime-operator.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $ca.Cert | b64enc }}
+  tls.key: {{ $ca.Key | b64enc }}
+---
+{{ $operatorCert := genSignedCert "wasmcloud-operator" nil nil 365 $ca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.global.certificates.operatorCertSecretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "runtime-operator.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $operatorCert.Cert | b64enc }}
+  tls.key: {{ $operatorCert.Key | b64enc }}
+  ca.crt: {{ $ca.Cert | b64enc }}
+---
+{{ $runtimeCert := genSignedCert "wasmcloud-runtime" nil nil 365 $ca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.global.certificates.runtimeCertSecretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "runtime-operator.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $runtimeCert.Cert | b64enc }}
+  tls.key: {{ $runtimeCert.Key | b64enc }}
+  ca.crt: {{ $ca.Cert | b64enc }}
+---
+{{ $dataCert := genSignedCert "wasmcloud-data" nil nil 365 $ca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.global.certificates.dataCertSecretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "runtime-operator.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $dataCert.Cert | b64enc }}
+  tls.key: {{ $dataCert.Key | b64enc }}
+  ca.crt: {{ $ca.Cert | b64enc }}
+---
+{{ $natsCert := genSignedCert "nats-server" nil nil 365 $ca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.global.certificates.natsCertSecretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "runtime-operator.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $natsCert.Cert | b64enc }}
+  tls.key: {{ $natsCert.Key | b64enc }}
+  ca.crt: {{ $ca.Cert | b64enc }}
+{{- end }}

--- a/charts/runtime-operator/templates/nats/config.yaml
+++ b/charts/runtime-operator/templates/nats/config.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.nats.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nats
+  namespace: {{ .Release.Namespace }}
+  labels:
+    wasmcloud.com/name: nats
+    {{- include "runtime-operator.labels" . | nindent 4 }}
+data:
+  nats-server.conf: |
+    port: 4222
+    jetstream: enabled
+
+    tls {
+      cert_file: /nats-cert/tls.crt
+      key_file: /nats-cert/tls.key
+      ca_file: /nats-cert/ca.crt
+      verify_and_map: true
+    }
+
+    authorization {
+      users = [
+        { user: "wasmcloud-operator" },
+        { user: "wasmcloud-runtime" },
+        { user: "wasmcloud-data" }
+      ]
+    }
+{{- end }}

--- a/charts/runtime-operator/templates/nats/deployment.yaml
+++ b/charts/runtime-operator/templates/nats/deployment.yaml
@@ -32,6 +32,7 @@ spec:
         - name: nats
           image: {{ printf "%s/%s" $registry .Values.nats.image.repository }}:{{ .Values.nats.image.tag | default "latest" }}
           args:
+            - "-DV"
             - "-c"
             - "/nats-config/nats-server.conf"
           imagePullPolicy: {{ .Values.nats.image.pull_policy }}

--- a/charts/runtime-operator/templates/nats/deployment.yaml
+++ b/charts/runtime-operator/templates/nats/deployment.yaml
@@ -19,14 +19,27 @@ spec:
         wasmcloud.com/name: nats
         {{- include "runtime-operator.labels" . | nindent 8 }}
     spec:
+      volumes:
+        - name: nats-config
+          configMap:
+            name: nats
+        - name: nats-cert
+          secret:
+            secretName: {{ .Values.global.certificates.natsCertSecretName }}
       serviceAccountName: {{ include "runtime-operator.serviceAccountName" . }}-nats
       {{- include "runtime-operator.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: nats
           image: {{ printf "%s/%s" $registry .Values.nats.image.repository }}:{{ .Values.nats.image.tag | default "latest" }}
           args:
-            - "-js"
+            - "-c"
+            - "/nats-config/nats-server.conf"
           imagePullPolicy: {{ .Values.nats.image.pull_policy }}
+          volumeMounts:
+            - name: nats-config
+              mountPath: /nats-config
+            - name: nats-cert
+              mountPath: /nats-cert
           ports:
             - name: nats
               containerPort: 4222

--- a/charts/runtime-operator/templates/operator/deployment.yaml
+++ b/charts/runtime-operator/templates/operator/deployment.yaml
@@ -18,6 +18,10 @@ spec:
         wasmcloud.com/name: runtime-operator
         {{- include "runtime-operator.labels" . | nindent 8 }}
     spec:
+      volumes:
+        - name: operator-cert
+          secret:
+            secretName: {{ .Values.global.certificates.operatorCertSecretName }}
       serviceAccountName: {{ include "runtime-operator.serviceAccountName" . }}
       {{- include "runtime-operator.imagePullSecrets" . | nindent 6 }}
       containers:
@@ -25,7 +29,14 @@ spec:
           image: {{ printf "%s/%s" $registry .Values.operator.image.repository }}:{{ .Values.operator.image.tag | default .Chart.AppVersion }}
           args:
             - "-nats-url=nats://nats:4222"
+            - "-nats-ca=/operator-cert/ca.crt"
+            - "-nats-client-cert=/operator-cert/tls.crt"
+            - "-nats-client-key=/operator-cert/tls.key"
           imagePullPolicy: {{ .Values.operator.image.pull_policy }}
+          volumeMounts:
+            - name: operator-cert
+              mountPath: /operator-cert
+              readOnly: true
           securityContext:
             capabilities:
               drop:

--- a/charts/runtime-operator/templates/runtime/deployment.yaml
+++ b/charts/runtime-operator/templates/runtime/deployment.yaml
@@ -23,6 +23,13 @@ spec:
         wasmcloud.com/hostgroup: {{ .name }}
         {{- include "runtime-operator.labels" $top | nindent 8 }}
     spec:
+      volumes:
+        - name: runtime-cert
+          secret:
+            secretName: {{ $top.Values.global.certificates.runtimeCertSecretName }}
+        - name: data-cert
+          secret:
+            secretName: {{ $top.Values.global.certificates.dataCertSecretName }}
       serviceAccountName: {{ include "runtime-operator.serviceAccountName" $top }}-runtime
       {{- include "runtime-operator.imagePullSecrets" $top | nindent 6 }}
       containers:
@@ -38,7 +45,13 @@ spec:
             - "--host-name=$(WASMCLOUD_HOST_IP)"
             - "--host-group={{ .name }}"
             - "--scheduler-nats-url=nats://nats:4222"
+            - "--scheduler-nats-tls-ca=/runtime-cert/ca.crt"
+            - "--scheduler-nats-tls-cert=/runtime-cert/tls.crt"
+            - "--scheduler-nats-tls-key=/runtime-cert/tls.key"
             - "--data-nats-url=nats://nats:4222"
+            - "--data-nats-tls-ca=/data-cert/ca.crt"
+            - "--data-nats-tls-cert=/data-cert/tls.crt"
+            - "--data-nats-tls-key=/data-cert/tls.key"
             {{- if and (.http) (.http.enabled) }}
             - "--http-addr=0.0.0.0:9191"
             {{- end }}
@@ -46,6 +59,13 @@ spec:
             - "--wasi-webgpu"
             {{- end }}
           imagePullPolicy: {{ $top.Values.runtime.image.pull_policy }}
+          volumeMounts:
+            - name: runtime-cert
+              mountPath: /runtime-cert
+              readOnly: true
+            - name: data-cert
+              mountPath: /data-cert
+              readOnly: true
           {{- with .resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/runtime-operator/values.yaml
+++ b/charts/runtime-operator/values.yaml
@@ -6,6 +6,19 @@ global:
     pullSecrets: []
   nameOverride: ""
   fullnameOverride: ""
+  certificates:
+    # -- Enable automatic generation of self-signed TLS certificates for the operator and runtime hosts
+    generate: true
+    # -- Name of the Kubernetes Secrets holding the Private CA certificate ( NATS )
+    caSecretName: wasmcloud-ca
+    # -- Name of the Kubernetes Secrets holding the TLS server certificates for NATS server (if enabled in this chart)
+    natsCertSecretName: wasmcloud-nats-tls
+    # -- Name of the Kubernetes Secrets holding the TLS client certificate for the operator
+    operatorCertSecretName: wasmcloud-operator-tls
+    # -- Name of the Kubernetes Secrets holding the TLS server certificates for control plane
+    runtimeCertSecretName: wasmcloud-runtime-tls
+    # -- Name of the Kubernetes Secrets holding the TLS server certificates for user data plane
+    dataCertSecretName: wasmcloud-data-tls
 
 # -- Values for installing a basic NATS Server with Ephemeral Storage. If you prefer to install NATS separately, set `enabled` to `false`.
 nats:

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -1,4 +1,4 @@
-use std::{net::SocketAddr, sync::Arc, time::Duration};
+use std::{net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
 
 use anyhow::Context as _;
 use clap::Args;
@@ -17,9 +17,41 @@ pub struct HostCommand {
     #[clap(long = "scheduler-nats-url", default_value = "nats://localhost:4222")]
     pub scheduler_nats_url: String,
 
+    /// Path to TLS CA certificate file for NATS Scheduler connection
+    #[clap(long = "scheduler-nats-tls-ca")]
+    pub scheduler_nats_tls_ca: Option<PathBuf>,
+
+    /// Enable TLS handshake first mode for NATS Scheduler connection
+    #[clap(long = "scheduler-nats-tls-first", default_value_t = false)]
+    pub scheduler_nats_tls_first: bool,
+
+    /// Path to NATS TLS certificate file for NATS Scheduler connection
+    #[clap(long = "scheduler-nats-tls-cert")]
+    pub scheduler_nats_tls_cert: Option<PathBuf>,
+
+    /// Path to NATS TLS private key file for NATS Scheduler connection
+    #[clap(long = "scheduler-nats-tls-key")]
+    pub scheduler_nats_tls_key: Option<PathBuf>,
+
     /// NATS URL for Data Plane communications
     #[clap(long = "data-nats-url", default_value = "nats://localhost:4222")]
     pub data_nats_url: String,
+
+    /// The path to TLS CA certificate file for NATS Data connection
+    #[clap(long = "data-nats-tls-ca")]
+    pub data_nats_tls_ca: Option<PathBuf>,
+
+    /// Enable TLS handshake first mode for NATS Data connection
+    #[clap(long = "data-nats-tls-first", default_value_t = false)]
+    pub data_nats_tls_first: bool,
+
+    /// Path to NATS TLS certificate file for NATS Data connection
+    #[clap(long = "data-nats-tls-cert")]
+    pub data_nats_tls_cert: Option<PathBuf>,
+
+    /// Path to NATS TLS private key file for NATS Data connection
+    #[clap(long = "data-nats-tls-key")]
+    pub data_nats_tls_key: Option<PathBuf>,
 
     /// The host name to assign to the host
     #[clap(long = "host-name")]
@@ -45,15 +77,31 @@ pub struct HostCommand {
 
 impl CliCommand for HostCommand {
     async fn handle(&self, _ctx: &CliContext) -> anyhow::Result<CommandOutput> {
-        let scheduler_nats_client =
-            wash_runtime::washlet::connect_nats(self.scheduler_nats_url.clone(), None)
-                .await
-                .context("failed to connect to NATS Scheduler URL")?;
+        let scheduler_nats_client = wash_runtime::washlet::connect_nats(
+            self.scheduler_nats_url.clone(),
+            wash_runtime::washlet::NatsConnectionOptions {
+                request_timeout: None,
+                tls_ca: self.scheduler_nats_tls_ca.clone(),
+                tls_first: self.scheduler_nats_tls_first,
+                tls_cert: self.scheduler_nats_tls_cert.clone(),
+                tls_key: self.scheduler_nats_tls_key.clone(),
+            },
+        )
+        .await
+        .context("failed to connect to NATS Scheduler URL")?;
 
-        let data_nats_client =
-            wash_runtime::washlet::connect_nats(self.data_nats_url.clone(), None)
-                .await
-                .context("failed to connect to NATS")?;
+        let data_nats_client = wash_runtime::washlet::connect_nats(
+            self.data_nats_url.clone(),
+            wash_runtime::washlet::NatsConnectionOptions {
+                request_timeout: None,
+                tls_ca: self.data_nats_tls_ca.clone(),
+                tls_first: self.data_nats_tls_first,
+                tls_cert: self.data_nats_tls_cert.clone(),
+                tls_key: self.data_nats_tls_key.clone(),
+            },
+        )
+        .await
+        .context("failed to connect to NATS")?;
         let data_nats_client = Arc::new(data_nats_client);
 
         let host_config = wash_runtime::host::HostConfig {

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -77,6 +77,10 @@ pub struct HostCommand {
 
 impl CliCommand for HostCommand {
     async fn handle(&self, _ctx: &CliContext) -> anyhow::Result<CommandOutput> {
+        rustls::crypto::aws_lc_rs::default_provider()
+            .install_default()
+            .map_err(|e| anyhow::anyhow!(format!("failed to install crypto provider: {e:?}")))?;
+
         let scheduler_nats_client = wash_runtime::washlet::connect_nats(
             self.scheduler_nats_url.clone(),
             wash_runtime::washlet::NatsConnectionOptions {

--- a/runtime-operator/cmd/main.go
+++ b/runtime-operator/cmd/main.go
@@ -61,6 +61,10 @@ func main() {
 		metricsAddr                 string
 		natsUrl                     string
 		natsCreds                   string
+		natsCa                      string
+		natsClientCert              string
+		natsClientKey               string
+		natsTLSFirst                bool
 		enableLeaderElection        bool
 		probeAddr                   string
 		secureMetrics               bool
@@ -75,6 +79,10 @@ func main() {
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8082", "The address the probe endpoint binds to.")
 	flag.StringVar(&natsCreds, "nats-creds", "", "Path to NATS credentials file.")
+	flag.StringVar(&natsCa, "nats-ca", "", "Path to TLS CA pem")
+	flag.StringVar(&natsClientCert, "nats-client-cert", "", "Path to TLS client certificate pem")
+	flag.StringVar(&natsClientKey, "nats-client-key", "", "Path to TLS client key pem")
+	flag.BoolVar(&natsTLSFirst, "nats-tls-first", false, "Skip NATS Server discovery during TLS")
 	flag.StringVar(&natsUrl, "nats-url", wasmbus.NatsDefaultURL, "The nats server address to connect to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
@@ -123,6 +131,18 @@ func main() {
 
 	if natsCreds != "" {
 		operatorCfg.NatsOptions = append(operatorCfg.NatsOptions, nats.UserCredentials(natsCreds))
+	}
+
+	if natsCa != "" {
+		operatorCfg.NatsOptions = append(operatorCfg.NatsOptions, nats.RootCAs(natsCa))
+	}
+
+	if natsClientCert != "" && natsClientKey != "" {
+		operatorCfg.NatsOptions = append(operatorCfg.NatsOptions, nats.ClientCert(natsClientCert, natsClientKey))
+	}
+
+	if natsTLSFirst {
+		operatorCfg.NatsOptions = append(operatorCfg.NatsOptions, nats.TLSHandshakeFirst())
 	}
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled


### PR DESCRIPTION
continuation of #183

Secures the default helm installation with client certificates.
Note: During upgrades, `certificates.generate` must be set to false to avoid outages.

Certificates map to NATS users:
- `wasmcloud-operator`: The Runtime Operator
- `wasmcloud-runtime`: Wash Host, control plane connection
- `wasmcloud-data`: Wash Host, data plane connection

The Runtime Operator and Wash Host Control Plane connections must be in the same NATS Account.
The Wash Host Data Plane connection is used by Plugins (blobstore, keyvalue) to manipulate user data.
