### PR TITLE
fix(wash): use cli context for relative paths

### DIFF
--- a/crates/wash/src/cli/new.rs
+++ b/crates/wash/src/cli/new.rs
@@ -3,7 +3,6 @@
 use anyhow::{Context, bail};
 use clap::Args;
 use serde_json::json;
-use std::path::PathBuf;
 use tracing::{info, instrument};
 
 use crate::{
@@ -35,7 +34,8 @@ impl CliCommand for NewCommand {
     #[instrument(level = "debug", skip(self, ctx), name = "new")]
     async fn handle(&self, ctx: &CliContext) -> anyhow::Result<CommandOutput> {
         let project_name = self.get_project_name();
-        let output_dir = PathBuf::from(&project_name);
+        // Explicitly use project_dir from context instead of relying on working directory
+        let output_dir = ctx.project_dir().join(&project_name);
 
         if output_dir.exists() {
             bail!("Output directory already exists: {}", output_dir.display());

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,8 @@ use tracing::{Level, error, info, instrument, trace, warn};
 use tracing_subscriber::{EnvFilter, Registry, layer::SubscriberExt, util::SubscriberInitExt};
 
 use wash::cli::{
-    CONFIG_DIR_NAME, CliCommand, CliCommandExt, CliContext, CommandOutput, OutputKind,
-    plugin::ComponentPluginCommand,
+    CONFIG_DIR_NAME, CONFIG_FILE_NAME, CliCommand, CliCommandExt, CliContext, CommandOutput,
+    OutputKind, plugin::ComponentPluginCommand,
 };
 
 #[derive(Debug, Clone, Parser)]
@@ -454,7 +454,9 @@ fn find_project_root() -> PathBuf {
     };
 
     loop {
-        if current_dir.join(CONFIG_DIR_NAME).exists() {
+        // Look for .wash/config.yaml (project config), not just .wash/ directory
+        let project_config = current_dir.join(CONFIG_DIR_NAME).join(CONFIG_FILE_NAME);
+        if project_config.exists() {
             return current_dir;
         }
 


### PR DESCRIPTION
Fixes the issue where we were changing the current cwd to the user's home dir as part of project resolution (no project exists yet) and we would resolve to ~. Then another side-effect is that wash new and oci were incorrectly resolving paths without basing them on the project_path in the CliContext.

- Had find_project_root check for config.yaml (I had cases where I had empty or old wash dirs)
- new and oci now use ctx.project_dir()