### PR TITLE
fix: avoid port collision in HttpServer tests

### DIFF
--- a/crates/wash-runtime/README.md
+++ b/crates/wash-runtime/README.md
@@ -39,7 +39,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Configure plugins
     let http_router = DynamicRouter::default();
-    let http_handler = HttpServer::new(http_router, "127.0.0.1:8080".parse()?);
+    let http_handler = HttpServer::new(http_router, "127.0.0.1:8080".parse()?).await?;
     let wasi_config_plugin = DynamicConfig::default();
 
     // Build and start the host

--- a/crates/wash-runtime/src/lib.rs
+++ b/crates/wash-runtime/src/lib.rs
@@ -33,7 +33,7 @@ mod test {
     async fn can_run_engine() -> anyhow::Result<()> {
         let engine = Engine::builder().build()?;
         let http_handler = crate::host::http::DevRouter::default();
-        let http_plugin = HttpServer::new(http_handler, "127.0.0.1:8080".parse()?);
+        let http_plugin = HttpServer::new(http_handler, "127.0.0.1:0".parse()?).await?;
         let wasi_config_plugin = DynamicConfig::default();
 
         let host = HostBuilder::new()

--- a/crates/wash-runtime/tests/common.rs
+++ b/crates/wash-runtime/tests/common.rs
@@ -1,9 +1,0 @@
-use anyhow::Result;
-
-/// Find an available port by binding to a random port (0) and returning the assigned port.
-pub async fn find_available_port() -> Result<u16> {
-    use tokio::net::TcpListener;
-    let listener = TcpListener::bind("127.0.0.1:0").await?;
-    let addr = listener.local_addr()?;
-    Ok(addr.port())
-}

--- a/crates/wash-runtime/tests/integration_http_blobstore.rs
+++ b/crates/wash-runtime/tests/integration_http_blobstore.rs
@@ -10,11 +10,8 @@
 //! Full component binding and request routing would require proper WIT interface configuration.
 
 use anyhow::{Context, Result};
-use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio::time::timeout;
-
-mod common;
-use common::find_available_port;
 
 use wash_runtime::{
     engine::Engine,
@@ -41,10 +38,8 @@ async fn test_http_blobstore_integration() -> Result<()> {
     let engine = Engine::builder().build()?;
 
     // Create HTTP server plugin on a dynamically allocated port
-    let port = find_available_port().await?;
-    let addr: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
-    let http_handler = DevRouter::default();
-    let http_plugin = HttpServer::new(http_handler, addr);
+    let http_plugin = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = http_plugin.addr();
 
     // Create blobstore plugin
     let blobstore_plugin = InMemoryBlobstore::new(None);
@@ -205,10 +200,7 @@ async fn test_plugin_lifecycle() -> Result<()> {
     println!("Testing plugin lifecycle");
 
     let engine = Engine::builder().build()?;
-    let port = find_available_port().await?;
-    let addr: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
-    let http_handler = DevRouter::default();
-    let http_plugin = HttpServer::new(http_handler, addr);
+    let http_plugin = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
 
     let host = HostBuilder::new()
         .with_engine(engine)

--- a/crates/wash-runtime/tests/integration_http_webgpu.rs
+++ b/crates/wash-runtime/tests/integration_http_webgpu.rs
@@ -11,11 +11,8 @@
 #![cfg(feature = "wasi-webgpu")]
 
 use anyhow::{Context, Result};
-use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio::time::timeout;
-
-mod common;
-use common::find_available_port;
 
 use wash_runtime::{
     engine::Engine,
@@ -42,10 +39,8 @@ async fn test_http_webgpu_integration() -> Result<()> {
     let engine = Engine::builder().build()?;
 
     // Create HTTP server plugin on a dynamically allocated port
-    let port = find_available_port().await?;
-    let addr: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
-    let http_handler = DevRouter::default();
-    let http_plugin = HttpServer::new(http_handler, addr);
+    let http_plugin = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = http_plugin.addr();
 
     // Build host with plugins following the existing pattern from lib.rs test
     let host = HostBuilder::new()

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -119,7 +119,7 @@ impl CliCommand for DevCommand {
         } else {
             debug!("No TLS configuration provided - server will use HTTP");
             let http_server =
-                wash_runtime::host::http::HttpServer::new(http_handler, http_addr.parse()?);
+                wash_runtime::host::http::HttpServer::new(http_handler, http_addr.parse()?).await?;
             host_builder = host_builder.with_http_handler(Arc::new(http_server));
             "http"
         };

--- a/crates/wash/src/cli/host.rs
+++ b/crates/wash/src/cli/host.rs
@@ -136,7 +136,7 @@ impl CliCommand for HostCommand {
         if let Some(addr) = self.http_addr {
             let http_router = wash_runtime::host::http::DynamicRouter::default();
             cluster_host_builder = cluster_host_builder.with_http_handler(Arc::new(
-                wash_runtime::host::http::HttpServer::new(http_router, addr),
+                wash_runtime::host::http::HttpServer::new(http_router, addr).await?,
             ));
         }
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,9 +1,0 @@
-use anyhow::Result;
-
-/// Find an available port by binding to a random port (0) and returning the assigned port.
-pub async fn find_available_port() -> Result<u16> {
-    use tokio::net::TcpListener;
-    let listener = TcpListener::bind("127.0.0.1:0").await?;
-    let addr = listener.local_addr()?;
-    Ok(addr.port())
-}

--- a/tests/integration_inter_component_call.rs
+++ b/tests/integration_inter_component_call.rs
@@ -9,14 +9,10 @@
 use anyhow::{Context, Result};
 use std::{
     collections::{HashMap, HashSet},
-    net::SocketAddr,
     sync::Arc,
     time::Duration,
 };
 use tokio::{sync::Mutex, time::timeout};
-
-mod common;
-use common::find_available_port;
 
 use wash_runtime::{
     engine::{
@@ -174,9 +170,8 @@ async fn test_inter_component_call() -> Result<()> {
     let engine = Engine::builder().build()?;
 
     // Create HTTP server plugin on a dynamically allocated port
-    let port = find_available_port().await?;
-    let addr: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
-    let http_plugin = HttpServer::new(DevRouter::default(), addr);
+    let http_plugin = HttpServer::new(DevRouter::default(), "127.0.0.1:0".parse()?).await?;
+    let addr = http_plugin.addr();
 
     // Create keyvalue plugin for counter persistence (still using built-in)
     let keyvalue_plugin = InMemoryKeyValue::new();


### PR DESCRIPTION
Tests called find_available_port() which binds a TcpListener to port 0,
reads the port, then drops the listener.

Later, HttpServer::start() tries to re-bind that same port.
Between the drop and re-bind, another test (running in parallel) can
grab that port.

HttpServer::new() binds the TcpListener eagerly and holds it. The socket
stays open from construction through to start(), which takes ownership
of the already-bound listener. The port is never released, so no other
process or test can steal it. Tests just pass "127.0.0.1:0" to new() and
call addr() to discover the port.
