### PR TITLE
feat: template cloning trigger ( `wash new` )

### DIFF
--- a/crates/wash/src/cli/mod.rs
+++ b/crates/wash/src/cli/mod.rs
@@ -9,6 +9,7 @@ use std::{
 
 use anyhow::{Context as _, bail, ensure};
 use bytes::Bytes;
+use dialoguer::{Confirm, theme::ColorfulTheme};
 use etcetera::{
     AppStrategy, AppStrategyArgs,
     app_strategy::{Windows, Xdg},
@@ -605,6 +606,17 @@ impl CliContext {
 
     pub fn host(&self) -> &Arc<Host> {
         &self.host
+    }
+
+    pub fn request_confirmation<S>(&self, prompt: S) -> anyhow::Result<bool>
+    where
+        S: Into<String>,
+    {
+        Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt(prompt)
+            .default(true)
+            .interact()
+            .context("failed to read user confirmation")
     }
 
     /// Call hooks for the specified hook type with the provided runtime context.

--- a/crates/wash/src/cli/new.rs
+++ b/crates/wash/src/cli/new.rs
@@ -11,7 +11,7 @@ use tracing::{info, instrument};
 use crate::{
     cli::{CliCommand, CliContext, CommandOutput},
     config::{Config, load_config},
-    new::{clone_template, extract_subfolder},
+    new::{clone_template, copy_dir_recursive, extract_subfolder},
 };
 
 /// Create a new component project from a git repository
@@ -63,10 +63,10 @@ impl CliCommand for NewCommand {
                 .await
                 .context("failed to extract subfolder")?;
         } else {
-            // Move entire cloned repository to output directory
-            tokio::fs::rename(tempdir.path(), &output_dir)
+            // Copy instead of move as we might be on a different filesystem
+            copy_dir_recursive(tempdir.path(), &output_dir)
                 .await
-                .context("failed to move cloned repository to output directory")?;
+                .context("failed to copy cloned repository to output directory")?;
         }
 
         // Check if the output directory has a wash config

--- a/crates/wash/src/cli/new.rs
+++ b/crates/wash/src/cli/new.rs
@@ -59,7 +59,7 @@ impl CliCommand for NewCommand {
 
         if let Some(subfolder) = &self.subfolder {
             // Extract subfolder if specified
-            extract_subfolder(ctx, &output_dir, subfolder)
+            extract_subfolder(tempdir.path(), &output_dir, subfolder)
                 .await
                 .context("failed to extract subfolder")?;
         } else {

--- a/crates/wash/src/cli/new.rs
+++ b/crates/wash/src/cli/new.rs
@@ -74,7 +74,12 @@ impl CliCommand for NewCommand {
             load_config(&ctx.user_config_path(), Some(&output_dir), None::<Config>)
                 .context("couldn't load template config")?;
 
-        if let Some(new_cmd) = template_config.new.and_then(|nc| nc.command) {
+        if let Some(new_cmd) = template_config.new.and_then(|nc| nc.command)
+            && ctx.request_confirmation(format!(
+                "Execute template setup command '{}'? This may modify the new project.",
+                new_cmd
+            ))?
+        {
             let (cmd_bin, first_arg) = {
                 #[cfg(not(windows))]
                 {

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -40,6 +40,10 @@ pub struct Config {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dev: Option<DevConfig>,
 
+    /// Wash new configuration (default: empty/optional)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new: Option<NewConfig>,
+
     /// WIT dependency management configuration (default: empty/optional)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wit: Option<WitConfig>,
@@ -52,6 +56,7 @@ impl Default for Config {
         Config {
             version: Some(env!("CARGO_PKG_VERSION").to_string()),
             build: None,
+            new: None,
             dev: None,
             wit: None,
         }
@@ -77,6 +82,13 @@ impl Config {
     pub fn build(&self) -> BuildConfig {
         self.build.clone().unwrap_or_default()
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct NewConfig {
+    /// Optional command to run after creating a new project
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
 }
 
 /// Configuration for building WebAssembly components


### PR DESCRIPTION
Adds `new.command` to wash config.

This command will be executed after git clone in `wash new`.

This gives template authors an opportunity to pre-flight the environment for `wash dev` & `wash build`.

Have not added any checks wrt wash & template version as there are no incompatibilities to validate atm.

wash will ask for users' permission to execute the template setup command.

<img width="1756" height="423" alt="Screenshot 2026-01-29 at 5 17 16 PM" src="https://github.com/user-attachments/assets/da58a534-ab96-4991-9be0-245b8b258bc0" />

