### PR TITLE
fix: many cli oddities

### DIFF
--- a/crates/wash/src/cli/oci.rs
+++ b/crates/wash/src/cli/oci.rs
@@ -56,6 +56,7 @@ pub struct PullCommand {
     #[clap(long = "insecure", default_value_t = false)]
     insecure: bool,
     /// Username for basic authentication
+    #[clap(short, long)]
     user: Option<String>,
     /// Password for basic authentication
     #[clap(short, long)]

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -135,6 +135,7 @@ pub struct DevComponent {
 pub struct DevConfig {
     /// Command to run the component in dev mode
     /// If not specified, defaults to 'build.command'.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub command: Option<String>,
     /// Address for the dev server to bind to (default: "0.0.0.0:8000")
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## `wash oci`
Adding `user` clap argument ( oci auth )

## `wash update`
Simplifying updates by removing major/minor/patch handling
Making `dry-run` a bit more verbose both in text & json formats

## `wash config show`
Updating wash config so we don't emit a `command: null` for the dev section