### PR TITLE
fix(runtime): add wasmtime gc features to fix build on non-windows

### DIFF
--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -41,7 +41,7 @@ uuid = { workspace = true, features = ["v4"] }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["sync", "net", "macros"] }
 tracing = { workspace = true }
-wasmtime = { workspace = true, features = ["component-model", "cranelift", "pooling-allocator"] }
+wasmtime = { workspace = true, features = ["component-model", "cranelift", "pooling-allocator", "gc", "gc-null"] }
 wasmtime-wasi = { workspace = true }
 wasmtime-wasi-io = { workspace = true }
 wasmtime-wasi-http = { workspace = true, features = ["default-send-request"] }


### PR DESCRIPTION
This PR adds the gc and gc-null features to the wasmtime dependency in wash-runtime.

This change is needed to fix build and test failures on non-Windows platforms when using the pooling allocator. Without these features, compilation fails due to missing methods like total_gc_heaps.

Related issue: #274