### PR TITLE
feat: Plugin for `wasmcloud:postgres`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,7 +1439,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
- "uuid 1.18.0",
+ "uuid",
 ]
 
 [[package]]
@@ -3317,7 +3317,7 @@ dependencies = [
  "portable-atomic",
  "smallvec",
  "tagptr",
- "uuid 1.18.0",
+ "uuid",
 ]
 
 [[package]]
@@ -4266,8 +4266,7 @@ dependencies = [
  "postgres-protocol",
  "serde",
  "serde_json",
- "uuid 0.8.2",
- "uuid 1.18.0",
+ "uuid",
 ]
 
 [[package]]
@@ -6549,12 +6548,6 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-
-[[package]]
-name = "uuid"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
@@ -6768,7 +6761,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
- "uuid 1.18.0",
+ "uuid",
  "wash-runtime",
  "wash-wasi",
  "wasm-metadata 0.244.0",
@@ -6836,7 +6829,7 @@ dependencies = [
  "tracing-subscriber",
  "ulid",
  "url",
- "uuid 1.18.0",
+ "uuid",
  "wash-wasi",
  "wasi-graphics-context-wasmtime",
  "wasi-webgpu-wasmtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,10 +127,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
 
 [[package]]
 name = "arraydeque"
@@ -470,6 +485,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
+name = "bigdecimal"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6773ddc0eafc0e509fb60e48dff7f450f8e674a0686ae8605e8d9901bd5eefa"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,8 +534,14 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -777,6 +822,12 @@ dependencies = [
  "wasm-bindgen",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "cidr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdf600c45bd958cf2945c445264471cca8b6c8e67bc87b71affd6d7e5682621"
 
 [[package]]
 name = "cipher"
@@ -1348,12 +1399,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static 1.5.0",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-postgres"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d697d376cbfa018c23eb4caab1fd1883dd9c906a8c034e8d9a3cb06a7e0bef9"
+dependencies = [
+ "async-trait",
+ "deadpool",
+ "getrandom 0.2.16",
+ "tokio",
+ "tokio-postgres",
+ "tracing",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
- "uuid",
+ "uuid 1.18.0",
 ]
 
 [[package]]
@@ -1363,8 +1449,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "der_derive",
+ "flagset",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1737,6 +1836,12 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
@@ -1824,6 +1929,12 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flate2"
@@ -2053,6 +2164,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "geo-types"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24f8647af4005fa11da47cd56252c6ef030be8fa97bdbf355e7dfb6348f0a82c"
+dependencies = [
+ "approx",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2097,7 +2219,7 @@ version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 dependencies = [
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "indexmap 2.12.0",
  "stable_deref_trait",
 ]
@@ -2478,7 +2600,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.0",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3079,6 +3201,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3185,7 +3317,7 @@ dependencies = [
  "portable-atomic",
  "smallvec",
  "tagptr",
- "uuid",
+ "uuid 1.18.0",
 ]
 
 [[package]]
@@ -3402,6 +3534,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -3933,6 +4075,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "pg_bigdecimal"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9855a94c74528af62c0ea236577af5e601263c1c404a6ac939b07c97c8e0216"
+dependencies = [
+ "bigdecimal 0.3.1",
+ "byteorder",
+ "bytes",
+ "num",
+ "postgres",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4030,6 +4203,71 @@ dependencies = [
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
  "serde",
+]
+
+[[package]]
+name = "postgres"
+version = "0.19.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "363e6dfbdd780d3aa3597b6eb430db76bb315fa9bad7fae595bb8def808b8470"
+dependencies = [
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-util",
+ "log",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "postgres-derive"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56df96f5394370d1b20e49de146f9e6c25aa9ae750f449c9d665eafecb3ccae6"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee9dd5fe15055d2b6806f4736aa0c9637217074e224bbec46d4041b91bb9491"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand 0.9.2",
+ "sha2",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613283563cd90e1dfc3518d548caee47e0e725455ed619881f5cf21f36de4b48"
+dependencies = [
+ "array-init",
+ "bit-vec 0.6.3",
+ "bytes",
+ "chrono",
+ "cidr",
+ "fallible-iterator 0.2.0",
+ "geo-types",
+ "postgres-derive",
+ "postgres-protocol",
+ "serde",
+ "serde_json",
+ "uuid 0.8.2",
+ "uuid 1.18.0",
 ]
 
 [[package]]
@@ -4356,7 +4594,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.31",
- "socket2",
+ "socket2 0.6.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4393,7 +4631,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.0",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5259,6 +5497,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "sized-chunks"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5290,6 +5534,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5341,6 +5595,17 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -5686,6 +5951,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5697,7 +5983,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.0",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -5711,6 +5997,47 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c95d533c83082bb6490e0189acaa0bbeef9084e60471b696ca6988cd0541fb0"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.9.2",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-util",
+ "whoami",
+]
+
+[[package]]
+name = "tokio-postgres-rustls"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27d684bad428a0f2481f42241f821db42c54e2dc81d8c00db8536c506b0a0144"
+dependencies = [
+ "const-oid",
+ "ring",
+ "rustls 0.23.31",
+ "tokio",
+ "tokio-postgres",
+ "tokio-rustls 0.26.2",
+ "x509-cert",
 ]
 
 [[package]]
@@ -5881,7 +6208,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "rustls-native-certs 0.8.1",
- "socket2",
+ "socket2 0.6.0",
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -6103,6 +6430,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.2",
+ "web-time",
+]
+
+[[package]]
 name = "uncased"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6118,6 +6455,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6131,6 +6474,12 @@ checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6197,6 +6546,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "uuid"
@@ -6413,7 +6768,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
- "uuid",
+ "uuid 1.18.0",
  "wash-runtime",
  "wash-wasi",
  "wasm-metadata 0.244.0",
@@ -6431,11 +6786,16 @@ dependencies = [
  "anyhow",
  "async-nats",
  "async-trait",
+ "bigdecimal 0.4.10",
+ "bit-vec 0.6.3",
  "bytes",
  "chrono",
+ "cidr",
+ "deadpool-postgres",
  "docker_credential",
  "futures",
  "gag",
+ "geo-types",
  "hostname",
  "hyper",
  "moka",
@@ -6451,6 +6811,8 @@ dependencies = [
  "pbjson 0.8.0",
  "pbjson-build 0.8.0",
  "pbjson-types 0.8.0",
+ "pg_bigdecimal",
+ "postgres-types",
  "prost 0.14.1",
  "reqwest",
  "rustls 0.23.31",
@@ -6462,6 +6824,8 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "tokio",
+ "tokio-postgres",
+ "tokio-postgres-rustls",
  "tokio-rustls 0.26.2",
  "tokio-util",
  "tonic",
@@ -6470,7 +6834,9 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "uuid",
+ "ulid",
+ "url",
+ "uuid 1.18.0",
  "wash-wasi",
  "wasi-graphics-context-wasmtime",
  "wasi-webgpu-wasmtime",
@@ -6478,6 +6844,7 @@ dependencies = [
  "wasmtime-wasi-http",
  "wasmtime-wasi-io",
  "wat",
+ "webpki-roots 0.26.11",
  "wit-component 0.244.0",
 ]
 
@@ -6556,6 +6923,12 @@ dependencies = [
  "wgpu-core",
  "wgpu-types",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -7323,7 +7696,7 @@ checksum = "27a75de515543b1897b26119f93731b385a19aea165a1ec5f0e3acecc229cae7"
 dependencies = [
  "arrayvec",
  "bit-set",
- "bit-vec",
+ "bit-vec 0.8.0",
  "bitflags",
  "bytemuck",
  "cfg_aliases",
@@ -7430,6 +7803,17 @@ dependencies = [
  "js-sys",
  "log",
  "thiserror 2.0.18",
+ "web-sys",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
  "web-sys",
 ]
 
@@ -8100,6 +8484,18 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+ "tls_codec",
+]
 
 [[package]]
 name = "xdg-home"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,19 @@ wit-component = { version = "0.244.0", default-features = false }
 wash-runtime = { path = "crates/wash-runtime", default-features = false }
 wat = { version = "1.244.0", default-features = false }
 
+# postgres deps
+bigdecimal = { version = "0.4", default-features = false }
+bit-vec = { version = "0.6", default-features = false }
+cidr = { version = "0.2", default-features = false }
+deadpool-postgres = { version = "0.14", default-features = false }
+geo-types = { version = "0.7", default-features = false }
+pg_bigdecimal = { version = "0.1", default-features = false }
+postgres-types = { version = "0.2", default-features = false }
+tokio-postgres = { version = "0.7", default-features = false }
+tokio-postgres-rustls = { version = "0.13", default-features = false }
+ulid = { version = "1", default-features = false }
+webpki-roots = { version = "0.26", default-features = false }
+
 # wasmtime-wasi deps
 bitflags = "2.0"
 cap-fs-ext = "3.4.4"

--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/lib.rs"
 workspace = true
 
 [features]
-default = ["wasi-config", "wasi-logging", "wasi-blobstore", "wasi-keyvalue", "washlet"]
+default = ["wasi-config", "wasi-logging", "wasi-blobstore", "wasi-keyvalue", "wasmcloud-postgres", "washlet"]
 oci = ["dep:oci-client", "dep:oci-wasm", "dep:docker_credential", "dep:sha2", "dep:wit-component"]
 washlet = ["oci"]
 wasi-config = []
@@ -23,6 +23,13 @@ wasi-logging = []
 wasi-blobstore = []
 wasi-keyvalue = []
 wasi-webgpu = ["dep:wasi-webgpu-wasmtime", "dep:wasi-graphics-context-wasmtime"]
+wasmcloud-postgres = [
+    "dep:tokio-postgres", "dep:tokio-postgres-rustls",
+    "dep:deadpool-postgres", "dep:postgres-types",
+    "dep:bigdecimal", "dep:pg_bigdecimal",
+    "dep:bit-vec", "dep:cidr", "dep:geo-types",
+    "dep:ulid", "dep:url", "dep:webpki-roots",
+]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -80,6 +87,20 @@ oci-client = { workspace = true, optional = true, features = ["rustls-tls", "rus
 oci-wasm = { workspace = true, optional = true, features = ["rustls-tls"] }
 sha2 = { workspace = true, optional = true }
 wit-component = { workspace = true, optional = true }
+
+# PostgreSQL dependencies (optional, behind 'wasmcloud-postgres' feature)
+bigdecimal = { optional = true, workspace = true }
+bit-vec = { optional = true, workspace = true }
+cidr = { optional = true, workspace = true, features = ["std"] }
+deadpool-postgres = { optional = true, workspace = true, features = ["rt_tokio_1"] }
+geo-types = { optional = true, workspace = true }
+pg_bigdecimal = { optional = true, workspace = true }
+postgres-types = { optional = true, workspace = true, features = ["derive", "with-serde_json-1", "with-chrono-0_4", "with-uuid-1", "with-geo-types-0_7", "with-bit-vec-0_6", "with-cidr-0_2", "array-impls"] }
+tokio-postgres = { optional = true, workspace = true, features = [ "runtime", "with-serde_json-1", "with-chrono-0_4", "with-geo-types-0_7", "array-impls", "with-bit-vec-0_6", "with-uuid-1" ] }
+tokio-postgres-rustls = { optional = true, workspace = true }
+ulid = { optional = true, workspace = true, features = ["std"] }
+url = { optional = true, workspace = true }
+webpki-roots = { optional = true, workspace = true }
 
 [build-dependencies]
 anyhow = { workspace = true, default-features = true }

--- a/crates/wash-runtime/src/plugin/mod.rs
+++ b/crates/wash-runtime/src/plugin/mod.rs
@@ -43,6 +43,9 @@ pub mod wasi_keyvalue;
 #[cfg(feature = "wasi-logging")]
 pub mod wasi_logging;
 
+#[cfg(all(feature = "wasmcloud-postgres", not(doctest)))]
+pub mod wasmcloud_postgres;
+
 pub mod wasmcloud_messaging;
 
 #[cfg(all(feature = "wasi-webgpu", not(target_os = "windows")))]

--- a/crates/wash-runtime/src/plugin/wasmcloud_postgres/conversions.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_postgres/conversions.rs
@@ -1,0 +1,1007 @@
+//! Type conversions between WIT-generated PgValue types and tokio-postgres types.
+//!
+//! Ported from wasmCloud's provider-sqldb-postgres reference implementation.
+
+use core::net::IpAddr;
+use std::collections::HashMap;
+use std::error::Error;
+use std::str::FromStr;
+
+use anyhow::{Context as _, bail};
+use bigdecimal::num_traits::Float;
+use bit_vec::BitVec;
+use bytes::{BufMut, BytesMut};
+use chrono::{
+    DateTime, Datelike, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Offset as _, Timelike,
+    Utc,
+};
+use cidr::IpCidr;
+use geo_types::{LineString, Point, Rect, coord};
+use pg_bigdecimal::PgNumeric;
+use postgres_types::{FromSql, IsNull, PgLsn, ToSql, Type as PgType};
+use tokio_postgres::Row;
+use uuid::Uuid;
+
+use super::bindings::wasmcloud::postgres::query::{PgValue, ResultRow};
+use super::bindings::wasmcloud::postgres::types::{
+    Date, HashableF64, MacAddressEui48, MacAddressEui64, Numeric, Offset, ResultRowEntry, Time,
+    Timestamp, TimestampTz,
+};
+
+// ── Helper functions ────────────────────────────────────────────────────────
+
+/// Build an `f64` from a mantissa, exponent and sign
+fn f64_from_components(mantissa: u64, exponent: i16, sign: i8) -> f64 {
+    let sign_f = sign as f64;
+    let mantissa_f = mantissa as f64;
+    let exponent_f = 2f64.powf(exponent as f64);
+    sign_f * mantissa_f * exponent_f
+}
+
+/// Build an `f64` from a simple tuple of mantissa, exponent and sign
+fn f64_from_tuple(t: &(u64, i16, i8)) -> f64 {
+    f64_from_components(t.0, t.1, t.2)
+}
+
+/// Convert [`Rect`] into a tuple of points (two `HashableF64` pairs)
+fn rect_to_hashable_f64s(r: Rect<f64>) -> ((HashableF64, HashableF64), (HashableF64, HashableF64)) {
+    let (bottom_left_x, bottom_left_y) = r.min().x_y();
+    let (top_right_x, top_right_y) = r.max().x_y();
+    (
+        (
+            bottom_left_x.integer_decode(),
+            bottom_left_y.integer_decode(),
+        ),
+        (top_right_x.integer_decode(), top_right_y.integer_decode()),
+    )
+}
+
+/// Convert a [`LineString`] (expected to have exactly two points) into a tuple of `HashableF64` pairs
+fn linestring_to_hashable_f64s_tuple(
+    l: LineString<f64>,
+) -> anyhow::Result<((HashableF64, HashableF64), (HashableF64, HashableF64))> {
+    match linestring_to_hashable_f64s(l)[..] {
+        [start, end] => Ok((start, end)),
+        _ => bail!("unexpected number of points in line string"),
+    }
+}
+
+/// Convert a [`LineString`] into a vector of point pairs
+fn linestring_to_hashable_f64s(l: LineString<f64>) -> Vec<(HashableF64, HashableF64)> {
+    l.into_points()
+        .into_iter()
+        .map(point_to_hashable_f64s)
+        .collect::<Vec<_>>()
+}
+
+/// Convert a [`Point`] into two `HashableF64`s
+fn point_to_hashable_f64s(p: Point<f64>) -> (HashableF64, HashableF64) {
+    let (x, y) = p.x_y();
+    (x.integer_decode(), y.integer_decode())
+}
+
+// ── MAC address helpers ─────────────────────────────────────────────────────
+
+fn mac_eui48_as_bytes(m: MacAddressEui48) -> [u8; 6] {
+    [
+        m.bytes.0, m.bytes.1, m.bytes.2, m.bytes.3, m.bytes.4, m.bytes.5,
+    ]
+}
+
+fn mac_eui64_as_bytes(m: MacAddressEui64) -> [u8; 8] {
+    [
+        m.bytes.0, m.bytes.1, m.bytes.2, m.bytes.3, m.bytes.4, m.bytes.5, m.bytes.6, m.bytes.7,
+    ]
+}
+
+// ── Date/Time conversions ───────────────────────────────────────────────────
+
+fn date_to_naive(d: &Date) -> anyhow::Result<NaiveDate> {
+    match d {
+        Date::PositiveInfinity => Ok(NaiveDate::MAX),
+        Date::NegativeInfinity => Ok(NaiveDate::MIN),
+        Date::Ymd((year, month, day)) => NaiveDate::from_ymd_opt(*year, *month, *day)
+            .with_context(|| format!("failed to build date from ymd ({year}/{month}/{day})")),
+    }
+}
+
+fn naive_to_date(nd: NaiveDate) -> Date {
+    match nd {
+        NaiveDate::MAX => Date::PositiveInfinity,
+        NaiveDate::MIN => Date::NegativeInfinity,
+        nd => Date::Ymd((nd.year(), nd.month(), nd.day())),
+    }
+}
+
+fn time_to_naive(t: &Time) -> anyhow::Result<NaiveTime> {
+    NaiveTime::from_hms_micro_opt(t.hour, t.min, t.sec, t.micro).with_context(|| {
+        format!(
+            "failed to convert time [{}h {}m {}s {}micro]",
+            t.hour, t.min, t.sec, t.micro
+        )
+    })
+}
+
+fn naive_to_time(nt: NaiveTime) -> Time {
+    Time {
+        hour: nt.hour(),
+        min: nt.minute(),
+        sec: nt.second(),
+        // Intentional truncation: postgres has microsecond precision
+        micro: nt.nanosecond() / 1_000,
+    }
+}
+
+fn timestamp_to_naive(ts: &Timestamp) -> anyhow::Result<NaiveDateTime> {
+    match &ts.date {
+        Date::PositiveInfinity => Ok(NaiveDateTime::MAX),
+        Date::NegativeInfinity => Ok(NaiveDateTime::MIN),
+        Date::Ymd(_) => Ok(NaiveDateTime::new(
+            date_to_naive(&ts.date)?,
+            time_to_naive(&ts.time)?,
+        )),
+    }
+}
+
+fn naive_to_timestamp(ndt: NaiveDateTime) -> Timestamp {
+    Timestamp {
+        date: naive_to_date(ndt.date()),
+        time: naive_to_time(ndt.time()),
+    }
+}
+
+fn offset_to_fixed(offset: Offset) -> anyhow::Result<FixedOffset> {
+    match offset {
+        Offset::EasternHemisphereSecs(secs) => FixedOffset::east_opt(secs)
+            .with_context(|| format!("failed to convert eastern hemisphere seconds [{secs}]")),
+        Offset::WesternHemisphereSecs(secs) => FixedOffset::west_opt(secs)
+            .with_context(|| format!("failed to convert western hemisphere seconds [{secs}]")),
+    }
+}
+
+fn timestamptz_to_utc(tstz: &TimestampTz) -> anyhow::Result<DateTime<Utc>> {
+    let fixed_offset = offset_to_fixed(tstz.offset)?;
+    let timestamp = timestamp_to_naive(&tstz.timestamp)?;
+    Ok(DateTime::<FixedOffset>::from_naive_utc_and_offset(timestamp, fixed_offset).into())
+}
+
+fn utc_to_timestamptz(dt: DateTime<Utc>) -> TimestampTz {
+    TimestampTz {
+        offset: Offset::WesternHemisphereSecs(dt.offset().fix().local_minus_utc()),
+        timestamp: naive_to_timestamp(dt.naive_local()),
+    }
+}
+
+// ── into_result_row ─────────────────────────────────────────────────────────
+
+/// Build a `ResultRow` from a [`Row`]
+pub(super) fn into_result_row(r: Row) -> ResultRow {
+    let mut rr = Vec::new();
+    for (idx, col) in r.columns().iter().enumerate() {
+        rr.push(ResultRowEntry {
+            column_name: col.name().into(),
+            value: r.get(idx),
+        });
+    }
+    rr
+}
+
+// ── ToSql for MacAddressEui48 ───────────────────────────────────────────────
+
+impl ToSql for MacAddressEui48 {
+    fn to_sql(
+        &self,
+        ty: &PgType,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        match ty {
+            &tokio_postgres::types::Type::MACADDR => {
+                out.put_slice(&mac_eui48_as_bytes(*self));
+                Ok(IsNull::No)
+            }
+            _ => Err("invalid Postgres type for EUI48 MAC address".into()),
+        }
+    }
+
+    fn accepts(ty: &PgType) -> bool {
+        matches!(ty, &tokio_postgres::types::Type::MACADDR)
+    }
+
+    tokio_postgres::types::to_sql_checked!();
+}
+
+impl ToSql for MacAddressEui64 {
+    fn to_sql(
+        &self,
+        ty: &PgType,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        match ty {
+            &tokio_postgres::types::Type::MACADDR8 => {
+                out.put_slice(&mac_eui64_as_bytes(*self));
+                Ok(IsNull::No)
+            }
+            _ => Err("invalid Postgres type for EUI64 MAC address".into()),
+        }
+    }
+
+    fn accepts(ty: &PgType) -> bool {
+        matches!(ty, &tokio_postgres::types::Type::MACADDR8)
+    }
+
+    tokio_postgres::types::to_sql_checked!();
+}
+
+// ── FromSql for MAC addresses ───────────────────────────────────────────────
+
+fn mac_eui48_from_bytes(bytes: &[u8]) -> Result<MacAddressEui48, Box<dyn Error + Sync + Send>> {
+    match bytes[..] {
+        [o0, o1, o2, o3, o4, o5] => Ok(MacAddressEui48 {
+            bytes: (o0, o1, o2, o3, o4, o5),
+        }),
+        _ => Err(format!(
+            "unexpected number of bytes ({}) in EUI48 mac address",
+            bytes.len()
+        )
+        .into()),
+    }
+}
+
+fn mac_eui64_from_bytes(bytes: &[u8]) -> Result<MacAddressEui64, Box<dyn Error + Sync + Send>> {
+    match bytes[..] {
+        [o0, o1, o2, o3, o4, o5, o6, o7] => Ok(MacAddressEui64 {
+            bytes: (o0, o1, o2, o3, o4, o5, o6, o7),
+        }),
+        _ => Err(format!(
+            "unexpected number of bytes ({}) in EUI64 mac address",
+            bytes.len()
+        )
+        .into()),
+    }
+}
+
+impl FromSql<'_> for MacAddressEui48 {
+    fn from_sql(ty: &PgType, raw: &[u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
+        match (ty, raw) {
+            (&tokio_postgres::types::Type::MACADDR, bytes) if bytes.len() == 6 => {
+                mac_eui48_from_bytes(bytes)
+            }
+            _ => Err("invalid type/raw input for EUI48 MAC address".into()),
+        }
+    }
+
+    fn accepts(ty: &PgType) -> bool {
+        matches!(ty, &tokio_postgres::types::Type::MACADDR)
+    }
+}
+
+impl FromSql<'_> for MacAddressEui64 {
+    fn from_sql(ty: &PgType, raw: &[u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
+        match (ty, raw) {
+            (&tokio_postgres::types::Type::MACADDR8, bytes) if bytes.len() == 8 => {
+                mac_eui64_from_bytes(bytes)
+            }
+            _ => Err("invalid type/raw input for EUI64 MAC address".into()),
+        }
+    }
+
+    fn accepts(ty: &PgType) -> bool {
+        matches!(ty, &tokio_postgres::types::Type::MACADDR8)
+    }
+}
+
+// ── ToSql for PgValue ───────────────────────────────────────────────────────
+
+impl ToSql for PgValue {
+    fn to_sql(
+        &self,
+        ty: &PgType,
+        out: &mut BytesMut,
+    ) -> Result<IsNull, Box<dyn Error + Sync + Send>> {
+        match self {
+            PgValue::Null => Ok(IsNull::Yes),
+            // Numeric
+            PgValue::BigInt(n) | PgValue::Int8(n) => n.to_sql(ty, out),
+            PgValue::Int8Array(ns) => ns.to_sql(ty, out),
+            PgValue::BigSerial(n) | PgValue::Serial8(n) => n.to_sql(ty, out),
+            PgValue::Bool(n) | PgValue::Boolean(n) => n.to_sql(ty, out),
+            PgValue::BoolArray(ns) => ns.to_sql(ty, out),
+            PgValue::Double(d) | PgValue::Float8(d) => f64_from_tuple(d).to_sql(ty, out),
+            PgValue::Float8Array(ds) => ds
+                .iter()
+                .map(f64_from_tuple)
+                .collect::<Vec<_>>()
+                .to_sql(ty, out),
+            PgValue::Real(d) | PgValue::Float4(d) => (f64_from_tuple(d) as f32).to_sql(ty, out),
+            PgValue::Float4Array(ds) => ds
+                .iter()
+                .map(|d| f64_from_tuple(d) as f32)
+                .collect::<Vec<_>>()
+                .to_sql(ty, out),
+            PgValue::Integer(n) | PgValue::Int(n) | PgValue::Int4(n) => n.to_sql(ty, out),
+            PgValue::Int4Array(ns) => ns.to_sql(ty, out),
+            PgValue::Numeric(s) | PgValue::Decimal(s) | PgValue::Money(s) => {
+                let bigd = pg_bigdecimal::BigDecimal::parse_bytes(s.as_bytes(), 10)
+                    .ok_or_else(|| format!("failed to parse bigint [{s}]"))?;
+                PgNumeric::new(Some(bigd)).to_sql(ty, out)
+            }
+            PgValue::NumericArray(ss) | PgValue::MoneyArray(ss) => ss
+                .iter()
+                .map(|s| {
+                    pg_bigdecimal::BigDecimal::parse_bytes(s.as_bytes(), 10)
+                        .map(|v| PgNumeric::new(Some(v)))
+                        .ok_or_else(|| format!("failed to parse bigint [{s}]"))
+                })
+                .collect::<Result<Vec<PgNumeric>, _>>()?
+                .to_sql(ty, out),
+            PgValue::SmallInt(n) | PgValue::Int2(n) => n.to_sql(ty, out),
+            PgValue::Int2Array(ns) => ns.to_sql(ty, out),
+            PgValue::Int2Vector(ns) => ns.to_sql(ty, out),
+            PgValue::Int2VectorArray(ns) => ns.to_sql(ty, out),
+            PgValue::Serial(n) | PgValue::Serial4(n) => n.to_sql(ty, out),
+            PgValue::SmallSerial(n) | PgValue::Serial2(n) => n.to_sql(ty, out),
+
+            // Bytes
+            PgValue::Bit((exact_size, bytes)) => {
+                if bytes.len() != *exact_size as usize {
+                    return Err("bitfield size does not match".into());
+                }
+                bytes.as_slice().to_sql(ty, out)
+            }
+            PgValue::BitArray(many_bits) => {
+                let mut vec: Vec<Vec<u8>> = Vec::new();
+                for (exact_size, bytes) in many_bits.iter() {
+                    if bytes.len() != *exact_size as usize {
+                        return Err("bitfield size does not match".into());
+                    }
+                    vec.push(bytes.to_vec());
+                }
+                vec.to_sql(ty, out)
+            }
+            PgValue::BitVarying((limit, bytes)) | PgValue::Varbit((limit, bytes)) => {
+                if limit.is_some_and(|limit| bytes.len() > limit as usize) {
+                    return Err("bit field length is greater than limit".into());
+                }
+                bytes.as_slice().to_sql(ty, out)
+            }
+            PgValue::VarbitArray(many_varbits) => {
+                let mut valid_varbits: Vec<Vec<u8>> = Vec::new();
+                for (limit, bytes) in many_varbits {
+                    if limit.is_some_and(|limit| bytes.len() > limit as usize) {
+                        return Err("bit field length is greater than limit".into());
+                    }
+                    valid_varbits.push(bytes.to_vec());
+                }
+                valid_varbits.to_sql(ty, out)
+            }
+            PgValue::Bytea(bytes) => bytes.as_slice().to_sql(ty, out),
+            PgValue::ByteaArray(many_bytes) => many_bytes
+                .iter()
+                .map(|b| b.as_slice())
+                .collect::<Vec<&[u8]>>()
+                .to_sql(ty, out),
+
+            // Characters
+            PgValue::Char((len, bytes)) => {
+                if bytes.len() != *len as usize {
+                    return Err("char length does not match specified size".into());
+                }
+                bytes.as_slice().to_sql(ty, out)
+            }
+            PgValue::CharArray(many_chars) => {
+                let mut valid_chars: Vec<&[u8]> = Vec::new();
+                for (len, bytes) in many_chars {
+                    if bytes.len() != *len as usize {
+                        return Err("char length does not match specified size".into());
+                    }
+                    valid_chars.push(bytes.as_slice());
+                }
+                valid_chars.to_sql(ty, out)
+            }
+            PgValue::Varchar((maybe_len, bytes)) => {
+                if let Some(limit) = maybe_len
+                    && bytes.len() > *limit as usize
+                {
+                    return Err(format!(
+                        "char length [{}] does not match specified limit [{limit}]",
+                        bytes.len(),
+                    )
+                    .into());
+                }
+                bytes.as_slice().to_sql(ty, out)
+            }
+            PgValue::VarcharArray(vs) => {
+                let mut valid_varchars: Vec<&[u8]> = Vec::new();
+                for (maybe_len, bytes) in vs {
+                    if let Some(limit) = maybe_len
+                        && bytes.len() > *limit as usize
+                    {
+                        return Err(format!(
+                            "char length [{}] does not match specified limit [{limit}]",
+                            bytes.len(),
+                        )
+                        .into());
+                    }
+                    valid_varchars.push(bytes.as_slice());
+                }
+                valid_varchars.to_sql(ty, out)
+            }
+
+            // Networking
+            PgValue::Cidr(cidr) => IpCidr::from_str(cidr)
+                .map_err(|e| format!("invalid cidr: {e}"))?
+                .to_sql(ty, out),
+            PgValue::CidrArray(cidrs) => cidrs
+                .iter()
+                .map(|v| IpCidr::from_str(v).map_err(|e| format!("invalid cidr: {e}")))
+                .collect::<Result<Vec<IpCidr>, _>>()?
+                .to_sql(ty, out),
+            PgValue::Inet(addr) => IpAddr::from_str(addr)
+                .map_err(|e| format!("invalid address: {e}"))?
+                .to_sql(ty, out),
+            PgValue::InetArray(inets) => inets
+                .iter()
+                .map(|v| IpAddr::from_str(v).map_err(|e| format!("invalid address: {e}")))
+                .collect::<Result<Vec<IpAddr>, _>>()?
+                .to_sql(ty, out),
+
+            // EUI-48 (octets)
+            PgValue::Macaddr(m) => m.to_sql(ty, out),
+            PgValue::MacaddrArray(macs) => macs.clone().to_sql(ty, out),
+
+            // EUI-64 (deprecated)
+            PgValue::Macaddr8(m) => m.to_sql(ty, out),
+            PgValue::Macaddr8Array(macs) => macs.clone().to_sql(ty, out),
+
+            // Geo
+            PgValue::Circle(_) | PgValue::CircleArray(_) => {
+                Err("circle & circle[] are not supported".into())
+            }
+            PgValue::Box(((start_x, start_y), (end_x, end_y))) => {
+                let start_x = f64_from_tuple(start_x);
+                let start_y = f64_from_tuple(start_y);
+                let end_x = f64_from_tuple(end_x);
+                let end_y = f64_from_tuple(end_y);
+                Rect::<f64>::new(
+                    coord! { x: start_x, y: start_y },
+                    coord! { x: end_x, y: end_y },
+                )
+                .to_sql(ty, out)
+            }
+            PgValue::Line(((start_x, start_y), (end_x, end_y)))
+            | PgValue::Lseg(((start_x, start_y), (end_x, end_y))) => LineString::<f64>::new(vec![
+                coord! { x: f64_from_tuple(start_x), y: f64_from_tuple(start_y) },
+                coord! { x: f64_from_tuple(end_x), y: f64_from_tuple(end_y) },
+            ])
+            .to_sql(ty, out),
+            PgValue::LineArray(lines) | PgValue::LsegArray(lines) => lines
+                .iter()
+                .map(|((start_x, start_y), (end_x, end_y))| {
+                    LineString::<f64>::new(vec![
+                        coord! { x: f64_from_tuple(start_x), y: f64_from_tuple(start_y) },
+                        coord! { x: f64_from_tuple(end_x), y: f64_from_tuple(end_y) },
+                    ])
+                })
+                .collect::<Vec<LineString>>()
+                .to_sql(ty, out),
+            PgValue::BoxArray(boxes) => boxes
+                .iter()
+                .map(|((start_x, start_y), (end_x, end_y))| {
+                    Rect::<f64>::new(
+                        coord! { x: f64_from_tuple(start_x), y: f64_from_tuple(start_y) },
+                        coord! { x: f64_from_tuple(end_x), y: f64_from_tuple(end_y) },
+                    )
+                })
+                .collect::<Vec<Rect<f64>>>()
+                .to_sql(ty, out),
+            PgValue::Point((x, y)) => {
+                Point::<f64>::new(f64_from_tuple(x), f64_from_tuple(y)).to_sql(ty, out)
+            }
+            PgValue::PointArray(points) => points
+                .iter()
+                .map(|(x, y)| Point::<f64>::new(f64_from_tuple(x), f64_from_tuple(y)))
+                .collect::<Vec<Point>>()
+                .to_sql(ty, out),
+            PgValue::Path(points) | PgValue::Polygon(points) => {
+                if points.is_empty() {
+                    return Err("invalid polygon, no points specified".into());
+                }
+                points
+                    .iter()
+                    .map(|(x, y)| Point::<f64>::new(f64_from_tuple(x), f64_from_tuple(y)))
+                    .collect::<Vec<Point<f64>>>()
+                    .to_sql(ty, out)
+            }
+            PgValue::PathArray(paths) | PgValue::PolygonArray(paths) => paths
+                .iter()
+                .map(|path| {
+                    path.iter()
+                        .map(|(x, y)| Point::<f64>::new(f64_from_tuple(x), f64_from_tuple(y)))
+                        .collect::<Vec<Point<f64>>>()
+                })
+                .collect::<Vec<Vec<Point<f64>>>>()
+                .to_sql(ty, out),
+
+            // Date-time
+            PgValue::Date(d) => {
+                let d: NaiveDate = date_to_naive(d)?;
+                d.to_sql(ty, out)
+            }
+            PgValue::DateArray(ds) => ds
+                .iter()
+                .map(date_to_naive)
+                .collect::<Result<Vec<NaiveDate>, _>>()?
+                .to_sql(ty, out),
+            PgValue::Interval(_) | PgValue::IntervalArray(_) => Err(
+                "interval not supported (consider using a cast like 'value'::text::interval)"
+                    .into(),
+            ),
+            PgValue::Time(t) => {
+                let t = time_to_naive(t)?;
+                t.to_sql(ty, out)
+            }
+            PgValue::TimeArray(ts) => ts
+                .iter()
+                .map(time_to_naive)
+                .collect::<Result<Vec<NaiveTime>, _>>()?
+                .to_sql(ty, out),
+            PgValue::TimeTz(_) | PgValue::TimeTzArray(_) => Err(
+                "timetz not supported (consider using a cast like 'value'::text::timetz)".into(),
+            ),
+            PgValue::Timestamp(ts) => {
+                let ts = timestamp_to_naive(ts)?;
+                ts.to_sql(ty, out)
+            }
+            PgValue::TimestampArray(tss) => tss
+                .iter()
+                .map(timestamp_to_naive)
+                .collect::<Result<Vec<NaiveDateTime>, _>>()?
+                .to_sql(ty, out),
+            PgValue::TimestampTz(tstz) => {
+                let tstz = timestamptz_to_utc(tstz)?;
+                tstz.to_sql(ty, out)
+            }
+            PgValue::TimestampTzArray(tstzs) => tstzs
+                .iter()
+                .map(timestamptz_to_utc)
+                .collect::<Result<Vec<DateTime<Utc>>, _>>()?
+                .to_sql(ty, out),
+
+            // JSON
+            PgValue::Json(s) | PgValue::Jsonb(s) => serde_json::Value::from_str(s)
+                .map_err(|e| format!("failed to parse JSON: {e}"))?
+                .to_sql(ty, out),
+            PgValue::JsonArray(json_strings) | PgValue::JsonbArray(json_strings) => json_strings
+                .iter()
+                .map(|s| serde_json::Value::from_str(s))
+                .collect::<Result<Vec<serde_json::Value>, _>>()?
+                .to_sql(ty, out),
+
+            // Postgres-internal
+            PgValue::PgLsn(offset) => PgLsn::from(*offset).to_sql(ty, out),
+            PgValue::PgLsnArray(offsets) => offsets
+                .iter()
+                .cloned()
+                .map(PgLsn::from)
+                .collect::<Vec<PgLsn>>()
+                .to_sql(ty, out),
+            PgValue::PgSnapshot((xmin, xmax, xip_list)) => format!(
+                "{xmin}:{xmax}:{}",
+                xip_list
+                    .iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<String>>()
+                    .join(","),
+            )
+            .to_sql(ty, out),
+            PgValue::TxidSnapshot(n) => n.to_sql(ty, out),
+
+            // Text
+            PgValue::Name(s) => s.to_sql(ty, out),
+            PgValue::NameArray(ss) => ss.to_sql(ty, out),
+            PgValue::Text(s) => s.to_sql(ty, out),
+            PgValue::TextArray(ss) => ss.to_sql(ty, out),
+            PgValue::Xml(s) => s.to_sql(ty, out),
+            PgValue::XmlArray(ss) => ss.to_sql(ty, out),
+
+            // Full Text Search
+            PgValue::TsQuery(s) => s.to_sql(ty, out),
+            PgValue::TsVector(_) => Err(
+                "tsvector not supported (consider using a cast like 'value'::text::tsvector)"
+                    .into(),
+            ),
+
+            // UUIDs
+            PgValue::Uuid(s) => Uuid::from_str(s)?.to_sql(ty, out),
+            PgValue::UuidArray(ss) => ss
+                .iter()
+                .map(|v| Uuid::from_str(v.as_ref()))
+                .collect::<Result<Vec<Uuid>, _>>()?
+                .to_sql(ty, out),
+
+            // Hstore
+            PgValue::Hstore(h) => {
+                let map = HashMap::<String, Option<String>>::from_iter(h.iter().cloned());
+                map.to_sql(ty, out)
+            }
+        }
+    }
+
+    fn accepts(_ty: &PgType) -> bool {
+        // Accept all types and provide specific error messages in to_sql
+        true
+    }
+
+    tokio_postgres::types::to_sql_checked!();
+}
+
+// ── FromSql for PgValue ─────────────────────────────────────────────────────
+
+impl FromSql<'_> for PgValue {
+    fn from_sql(ty: &PgType, raw: &[u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
+        match ty {
+            &tokio_postgres::types::Type::BOOL => Ok(PgValue::Bool(bool::from_sql(ty, raw)?)),
+            &tokio_postgres::types::Type::BOOL_ARRAY => {
+                Ok(PgValue::BoolArray(Vec::<bool>::from_sql(ty, raw)?))
+            }
+            &tokio_postgres::types::Type::BYTEA => {
+                let buf = Vec::<u8>::from_sql(ty, raw)?;
+                Ok(PgValue::Bytea(buf))
+            }
+            &tokio_postgres::types::Type::BYTEA_ARRAY => {
+                let buf = Vec::<Vec<u8>>::from_sql(ty, raw)?;
+                Ok(PgValue::ByteaArray(buf))
+            }
+            &tokio_postgres::types::Type::CHAR => {
+                let s = Vec::<u8>::from_sql(ty, raw)?;
+                let len = s.len().try_into()?;
+                Ok(PgValue::Char((len, s)))
+            }
+            &tokio_postgres::types::Type::CHAR_ARRAY => {
+                let list = Vec::<Vec<u8>>::from_sql(ty, raw)?;
+                let mut cs = Vec::new();
+                for c in list {
+                    cs.push((c.len().try_into()?, c));
+                }
+                Ok(PgValue::CharArray(cs))
+            }
+            &tokio_postgres::types::Type::BIT => {
+                let vec = BitVec::from_sql(ty, raw)?;
+                let len = vec.len().try_into()?;
+                Ok(PgValue::Bit((len, vec.to_bytes())))
+            }
+            &tokio_postgres::types::Type::BIT_ARRAY => {
+                let vecs = Vec::<BitVec>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(|v| v.len().try_into().map(|len| (len, v.to_bytes())))
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(PgValue::BitArray(vecs))
+            }
+            &tokio_postgres::types::Type::VARBIT => {
+                let vec = BitVec::from_sql(ty, raw)?;
+                let len = vec.len().try_into()?;
+                Ok(PgValue::BitVarying((Some(len), vec.to_bytes())))
+            }
+            &tokio_postgres::types::Type::VARBIT_ARRAY => {
+                let varbits = Vec::<BitVec>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(|v| {
+                        let len = v.len().try_into().ok();
+                        (len, v.to_bytes())
+                    })
+                    .collect::<Vec<_>>();
+                Ok(PgValue::VarbitArray(varbits))
+            }
+            &tokio_postgres::types::Type::FLOAT4 => {
+                Ok(PgValue::Float4(f32::from_sql(ty, raw)?.integer_decode()))
+            }
+            &tokio_postgres::types::Type::FLOAT4_ARRAY => Ok(PgValue::Float4Array(
+                Vec::<f32>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(|f| f.integer_decode())
+                    .collect::<Vec<_>>(),
+            )),
+            &tokio_postgres::types::Type::FLOAT8 => {
+                Ok(PgValue::Float8(f64::from_sql(ty, raw)?.integer_decode()))
+            }
+            &tokio_postgres::types::Type::FLOAT8_ARRAY => Ok(PgValue::Float8Array(
+                Vec::<f64>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(|f| f.integer_decode())
+                    .collect::<Vec<_>>(),
+            )),
+            &tokio_postgres::types::Type::INT2 => Ok(PgValue::Int2(i16::from_sql(ty, raw)?)),
+            &tokio_postgres::types::Type::INT2_ARRAY => {
+                Ok(PgValue::Int2Array(Vec::<i16>::from_sql(ty, raw)?))
+            }
+            &tokio_postgres::types::Type::INT2_VECTOR => {
+                Ok(PgValue::Int2Vector(Vec::<i16>::from_sql(ty, raw)?))
+            }
+            &tokio_postgres::types::Type::INT2_VECTOR_ARRAY => Ok(PgValue::Int2VectorArray(
+                Vec::<Vec<i16>>::from_sql(ty, raw)?,
+            )),
+            &tokio_postgres::types::Type::INT4 => Ok(PgValue::Int4(i32::from_sql(ty, raw)?)),
+            &tokio_postgres::types::Type::INT4_RANGE
+            | &tokio_postgres::types::Type::INT4_RANGE_ARRAY
+            | &tokio_postgres::types::Type::INT4MULTI_RANGE
+            | &tokio_postgres::types::Type::INT4MULTI_RANGE_ARRAY => {
+                Err("int4 ranges are not yet supported".into())
+            }
+            &tokio_postgres::types::Type::INT4_ARRAY => Ok(PgValue::Int4Array(
+                Vec::<i32>::from_sql(ty, raw)?.into_iter().collect(),
+            )),
+            &tokio_postgres::types::Type::INT8 => Ok(PgValue::Int8(i64::from_sql(ty, raw)?)),
+            &tokio_postgres::types::Type::INT8_ARRAY => {
+                Ok(PgValue::Int8Array(Vec::<i64>::from_sql(ty, raw)?))
+            }
+            &tokio_postgres::types::Type::INT8MULTI_RANGE
+            | &tokio_postgres::types::Type::INT8MULTI_RANGE_ARRAY
+            | &tokio_postgres::types::Type::INT8_RANGE
+            | &tokio_postgres::types::Type::INT8_RANGE_ARRAY => {
+                Err("int8 ranges are not yet supported".into())
+            }
+
+            &tokio_postgres::types::Type::MONEY => Ok(PgValue::Money(Numeric::from_sql(ty, raw)?)),
+            &tokio_postgres::types::Type::MONEY_ARRAY => {
+                Ok(PgValue::MoneyArray(Vec::<Numeric>::from_sql(ty, raw)?))
+            }
+            &tokio_postgres::types::Type::NUMERIC => {
+                Ok(PgValue::Numeric(Numeric::from_sql(ty, raw)?))
+            }
+            &tokio_postgres::types::Type::NUMERIC_ARRAY => {
+                Ok(PgValue::NumericArray(Vec::<Numeric>::from_sql(ty, raw)?))
+            }
+            &tokio_postgres::types::Type::NUMMULTI_RANGE
+            | &tokio_postgres::types::Type::NUMMULTI_RANGE_ARRAY
+            | &tokio_postgres::types::Type::NUM_RANGE
+            | &tokio_postgres::types::Type::NUM_RANGE_ARRAY => {
+                Err("numeric ranges are not yet supported".into())
+            }
+
+            // JSON
+            &tokio_postgres::types::Type::JSON => Ok(PgValue::Json(
+                serde_json::Value::from_sql(ty, raw)?.to_string(),
+            )),
+            &tokio_postgres::types::Type::JSON_ARRAY => Ok(PgValue::JsonArray(
+                Vec::<serde_json::Value>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>(),
+            )),
+            &tokio_postgres::types::Type::JSONB => Ok(PgValue::Jsonb(
+                serde_json::Value::from_sql(ty, raw)?.to_string(),
+            )),
+            &tokio_postgres::types::Type::JSONB_ARRAY => Ok(PgValue::JsonbArray(
+                Vec::<serde_json::Value>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>(),
+            )),
+            &tokio_postgres::types::Type::VARCHAR => Ok(PgValue::Varchar(
+                Vec::<u8>::from_sql(ty, raw).map(|v| (None, v))?,
+            )),
+            &tokio_postgres::types::Type::VARCHAR_ARRAY => Ok(PgValue::VarcharArray(
+                Vec::<Vec<u8>>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(|s| (None, s))
+                    .collect::<Vec<_>>(),
+            )),
+            &tokio_postgres::types::Type::NAME => Ok(PgValue::Name(String::from_sql(ty, raw)?)),
+            &tokio_postgres::types::Type::NAME_ARRAY => {
+                Ok(PgValue::NameArray(Vec::<String>::from_sql(ty, raw)?))
+            }
+            &tokio_postgres::types::Type::TEXT => Ok(PgValue::Text(String::from_sql(ty, raw)?)),
+            &tokio_postgres::types::Type::TEXT_ARRAY => {
+                Ok(PgValue::TextArray(Vec::<String>::from_sql(ty, raw)?))
+            }
+            &tokio_postgres::types::Type::XML => Ok(PgValue::Xml(String::from_sql(ty, raw)?)),
+            &tokio_postgres::types::Type::XML_ARRAY => {
+                Ok(PgValue::XmlArray(Vec::<String>::from_sql(ty, raw)?))
+            }
+            &tokio_postgres::types::Type::BOX => Ok(PgValue::Box(rect_to_hashable_f64s(
+                Rect::<f64>::from_sql(ty, raw)?,
+            ))),
+            &tokio_postgres::types::Type::BOX_ARRAY => Ok(PgValue::BoxArray(
+                Vec::<Rect<f64>>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(rect_to_hashable_f64s)
+                    .collect::<Vec<_>>(),
+            )),
+            &tokio_postgres::types::Type::CIRCLE | &tokio_postgres::types::Type::CIRCLE_ARRAY => {
+                Err("circle & circle[] are not supported".into())
+            }
+            &tokio_postgres::types::Type::LINE => Ok(PgValue::Line(
+                linestring_to_hashable_f64s_tuple(LineString::<f64>::from_sql(ty, raw)?)?,
+            )),
+            &tokio_postgres::types::Type::LINE_ARRAY => Ok(PgValue::LineArray(
+                Vec::<LineString<f64>>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(linestring_to_hashable_f64s_tuple)
+                    .collect::<Result<Vec<_>, _>>()?,
+            )),
+            &tokio_postgres::types::Type::LSEG => Ok(PgValue::Lseg(
+                linestring_to_hashable_f64s_tuple(LineString::<f64>::from_sql(ty, raw)?)?,
+            )),
+            &tokio_postgres::types::Type::LSEG_ARRAY => Ok(PgValue::LsegArray(
+                Vec::<LineString<f64>>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(linestring_to_hashable_f64s_tuple)
+                    .collect::<Result<Vec<_>, _>>()?,
+            )),
+            &tokio_postgres::types::Type::PATH => Ok(PgValue::Path(
+                Vec::<Point<f64>>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(point_to_hashable_f64s)
+                    .collect::<Vec<_>>(),
+            )),
+            &tokio_postgres::types::Type::PATH_ARRAY => Ok(PgValue::PathArray(
+                Vec::<Vec<Point<f64>>>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(|points| points.into_iter().map(point_to_hashable_f64s).collect())
+                    .collect::<Vec<_>>(),
+            )),
+            &tokio_postgres::types::Type::POINT => {
+                let point = Point::<f64>::from_sql(ty, raw)?;
+                Ok(PgValue::Point(point_to_hashable_f64s(point)))
+            }
+            &tokio_postgres::types::Type::POINT_ARRAY => Ok(PgValue::PointArray(
+                Vec::<Point<f64>>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(point_to_hashable_f64s)
+                    .collect::<Vec<_>>(),
+            )),
+            &tokio_postgres::types::Type::POLYGON => Ok(PgValue::Polygon(
+                Vec::<Point<f64>>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(point_to_hashable_f64s)
+                    .collect::<Vec<_>>(),
+            )),
+            &tokio_postgres::types::Type::POLYGON_ARRAY => Ok(PgValue::PolygonArray(
+                Vec::<Vec<Point<f64>>>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(|v| v.into_iter().map(point_to_hashable_f64s).collect())
+                    .collect::<Vec<Vec<_>>>(),
+            )),
+
+            &tokio_postgres::types::Type::CIDR => {
+                let cidr = IpCidr::from_sql(ty, raw)?;
+                Ok(PgValue::Cidr(cidr.to_string()))
+            }
+            &tokio_postgres::types::Type::CIDR_ARRAY => Ok(PgValue::CidrArray(
+                Vec::<IpCidr>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(|c| c.to_string())
+                    .collect::<Vec<String>>(),
+            )),
+            &tokio_postgres::types::Type::INET => {
+                let inet = IpAddr::from_sql(ty, raw)?;
+                Ok(PgValue::Inet(inet.to_string()))
+            }
+            &tokio_postgres::types::Type::INET_ARRAY => Ok(PgValue::InetArray(
+                Vec::<IpAddr>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(|i| i.to_string())
+                    .collect::<Vec<String>>(),
+            )),
+
+            &tokio_postgres::types::Type::MACADDR => {
+                Ok(PgValue::Macaddr(MacAddressEui48::from_sql(ty, raw)?))
+            }
+            &tokio_postgres::types::Type::MACADDR_ARRAY => Ok(PgValue::MacaddrArray(
+                Vec::<MacAddressEui48>::from_sql(ty, raw)?,
+            )),
+            &tokio_postgres::types::Type::MACADDR8 => {
+                Ok(PgValue::Macaddr8(MacAddressEui64::from_sql(ty, raw)?))
+            }
+            &tokio_postgres::types::Type::MACADDR8_ARRAY => Ok(PgValue::Macaddr8Array(
+                Vec::<MacAddressEui64>::from_sql(ty, raw)?,
+            )),
+            &tokio_postgres::types::Type::DATE => {
+                Ok(PgValue::Date(naive_to_date(NaiveDate::from_sql(ty, raw)?)))
+            }
+            &tokio_postgres::types::Type::DATE_ARRAY => Ok(PgValue::DateArray(
+                Vec::<NaiveDate>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(naive_to_date)
+                    .collect::<Vec<Date>>(),
+            )),
+
+            &tokio_postgres::types::Type::DATE_RANGE
+            | &tokio_postgres::types::Type::DATE_RANGE_ARRAY
+            | &tokio_postgres::types::Type::DATEMULTI_RANGE => {
+                Err("date ranges are not yet supported".into())
+            }
+
+            &tokio_postgres::types::Type::TIME => {
+                Ok(PgValue::Time(naive_to_time(NaiveTime::from_sql(ty, raw)?)))
+            }
+            &tokio_postgres::types::Type::TIME_ARRAY => Ok(PgValue::TimeArray(
+                Vec::<NaiveTime>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(naive_to_time)
+                    .collect::<Vec<Time>>(),
+            )),
+            &tokio_postgres::types::Type::TIMESTAMP => Ok(PgValue::Timestamp(
+                naive_to_timestamp(NaiveDateTime::from_sql(ty, raw)?),
+            )),
+            &tokio_postgres::types::Type::TIMESTAMP_ARRAY => Ok(PgValue::TimestampArray(
+                Vec::<NaiveDateTime>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(naive_to_timestamp)
+                    .collect::<Vec<Timestamp>>(),
+            )),
+
+            &tokio_postgres::types::Type::INTERVAL
+            | &tokio_postgres::types::Type::INTERVAL_ARRAY => {
+                Err("intervals are not yet supported".into())
+            }
+
+            &tokio_postgres::types::Type::TIMETZ | &tokio_postgres::types::Type::TIMETZ_ARRAY => {
+                Err("timetz is not supported".into())
+            }
+
+            &tokio_postgres::types::Type::TS_RANGE
+            | &tokio_postgres::types::Type::TS_RANGE_ARRAY
+            | &tokio_postgres::types::Type::TSMULTI_RANGE
+            | &tokio_postgres::types::Type::TSMULTI_RANGE_ARRAY => {
+                Err("timestamp ranges are not yet supported".into())
+            }
+
+            &tokio_postgres::types::Type::TIMESTAMPTZ => Ok(PgValue::TimestampTz(
+                utc_to_timestamptz(DateTime::<Utc>::from_sql(ty, raw)?),
+            )),
+            &tokio_postgres::types::Type::TIMESTAMPTZ_ARRAY => Ok(PgValue::TimestampTzArray(
+                Vec::<DateTime<Utc>>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(utc_to_timestamptz)
+                    .collect::<Vec<TimestampTz>>(),
+            )),
+
+            &tokio_postgres::types::Type::TSTZ_RANGE
+            | &tokio_postgres::types::Type::TSTZ_RANGE_ARRAY
+            | &tokio_postgres::types::Type::TSTZMULTI_RANGE => {
+                Err("timestamptz ranges are not yet supported".into())
+            }
+
+            &tokio_postgres::types::Type::UUID => {
+                Ok(PgValue::Uuid(Uuid::from_sql(ty, raw)?.to_string()))
+            }
+            &tokio_postgres::types::Type::UUID_ARRAY => Ok(PgValue::UuidArray(
+                Vec::<Uuid>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<String>>(),
+            )),
+            &tokio_postgres::types::Type::PG_LSN => {
+                Ok(PgValue::PgLsn(PgLsn::from_sql(ty, raw)?.into()))
+            }
+            &tokio_postgres::types::Type::PG_LSN_ARRAY => Ok(PgValue::PgLsnArray(
+                Vec::<PgLsn>::from_sql(ty, raw)?
+                    .into_iter()
+                    .map(|v| v.into())
+                    .collect::<Vec<u64>>(),
+            )),
+
+            // Extension types (matched by name since they have no built-in Type constant)
+            t if t.name() == "hstore" => {
+                let map = HashMap::<String, Option<String>>::from_sql(ty, raw)?;
+                Ok(PgValue::Hstore(map.into_iter().collect()))
+            }
+
+            // All other types are unsupported
+            t => Err(format!(
+                "unsupported type [{t}], consider using a cast like 'value'::string or 'value'::jsonb"
+            )
+            .into()),
+        }
+    }
+
+    fn accepts(_ty: &PgType) -> bool {
+        // Accept all types and provide specific error messages in from_sql
+        true
+    }
+
+    fn from_sql_null(_ty: &PgType) -> Result<Self, Box<dyn Error + Sync + Send>> {
+        Ok(PgValue::Null)
+    }
+}

--- a/crates/wash-runtime/src/plugin/wasmcloud_postgres/mod.rs
+++ b/crates/wash-runtime/src/plugin/wasmcloud_postgres/mod.rs
@@ -1,0 +1,550 @@
+mod conversions;
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use anyhow::{Context as _, bail};
+use deadpool_postgres::{Manager, ManagerConfig, Pool, RecyclingMethod};
+use futures::TryStreamExt;
+use tokio::sync::RwLock;
+use tokio_postgres::types::Type as PgType;
+use tracing::instrument;
+use url::Url;
+
+use crate::engine::ctx::{ActiveCtx, SharedCtx, extract_active_ctx};
+use crate::engine::workload::WorkloadItem;
+use crate::plugin::HostPlugin;
+use crate::wit::{WitInterface, WitWorld};
+
+use conversions::into_result_row;
+
+const PLUGIN_POSTGRES_ID: &str = "wasmcloud-postgres";
+const DEFAULT_POOL_SIZE: usize = 10;
+
+mod bindings {
+    crate::wasmtime::component::bindgen!({
+        world: "postgres",
+        imports: { default: async | trappable | tracing },
+    });
+}
+
+use bindings::wasmcloud::postgres::prepared;
+use bindings::wasmcloud::postgres::query;
+use bindings::wasmcloud::postgres::types;
+
+use query::{PgValue, QueryError};
+
+use prepared::{PreparedStatementExecError, StatementPrepareError};
+
+/// A prepared statement entry stored by the plugin.
+/// Contains the original SQL, the inferred parameter types, and the database name.
+struct PreparedEntry {
+    sql: String,
+    param_types: Vec<PgType>,
+    database: String,
+    component_id: String,
+}
+
+/// wasmcloud:postgres host plugin.
+///
+/// Manages postgres connection pools at the host level and routes workload
+/// queries to the appropriate database via a connection bouncer pattern.
+#[derive(Clone)]
+pub struct WasmcloudPostgres {
+    /// Base config parsed from URL (no dbname set)
+    base_config: tokio_postgres::Config,
+    /// Max pool size per database
+    pool_size: usize,
+    /// Whether TLS should be used for connections
+    tls: bool,
+    /// database_name -> Pool
+    pools: Arc<RwLock<HashMap<String, Pool>>>,
+    /// prepared_statement_token -> PreparedEntry
+    prepared_statements: Arc<RwLock<HashMap<String, PreparedEntry>>>,
+    /// component_id -> database_name
+    component_databases: Arc<RwLock<HashMap<String, String>>>,
+    /// Notifies the pool reaper that an unbind happened
+    pool_reaper_notify: Arc<tokio::sync::Notify>,
+}
+
+impl WasmcloudPostgres {
+    /// Create a new WasmcloudPostgres plugin from a postgres URL.
+    ///
+    /// The URL should contain credentials, host/port, sslmode, and optionally pool_size.
+    /// The database name should NOT be included - workloads provide it via config.
+    ///
+    /// Example: `postgres://user:pass@bouncer:6432?sslmode=require&pool_size=10`
+    pub fn new(url: &str) -> anyhow::Result<Self> {
+        let parsed = Url::parse(url).context("failed to parse postgres URL")?;
+        let mut config: tokio_postgres::Config =
+            url.parse().context("failed to parse postgres config")?;
+
+        // Extract pool_size from the URL (not a standard postgres param, we parse it ourselves)
+        let pool_size = extract_pool_size(&parsed);
+
+        // Determine TLS from sslmode
+        let tls = extract_tls_requirement(&parsed);
+
+        // Strip dbname from the base config - workloads set this via their config
+        config.dbname("");
+
+        Ok(Self {
+            base_config: config,
+            pool_size,
+            tls,
+            pools: Arc::new(RwLock::new(HashMap::new())),
+            prepared_statements: Arc::new(RwLock::new(HashMap::new())),
+            component_databases: Arc::new(RwLock::new(HashMap::new())),
+            pool_reaper_notify: Arc::new(tokio::sync::Notify::new()),
+        })
+    }
+
+    /// Get or lazily create a connection pool for the given database name.
+    async fn get_or_create_pool(&self, database: &str) -> anyhow::Result<Pool> {
+        // Fast path: pool already exists
+        {
+            let pools = self.pools.read().await;
+            if let Some(pool) = pools.get(database) {
+                return Ok(pool.clone());
+            }
+        }
+
+        // Slow path: create pool
+        let mut pools = self.pools.write().await;
+        // Double-check after acquiring write lock
+        if let Some(pool) = pools.get(database) {
+            return Ok(pool.clone());
+        }
+
+        let mut pg_config = self.base_config.clone();
+        pg_config.dbname(database);
+
+        let mgr_config = ManagerConfig {
+            recycling_method: RecyclingMethod::Fast,
+        };
+
+        let pool = if self.tls {
+            let tls_config = rustls::ClientConfig::builder()
+                .with_root_certificates(rustls::RootCertStore {
+                    roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+                })
+                .with_no_client_auth();
+            let tls = tokio_postgres_rustls::MakeRustlsConnect::new(tls_config);
+            let mgr = Manager::from_config(pg_config, tls, mgr_config);
+            Pool::builder(mgr)
+                .max_size(self.pool_size)
+                .build()
+                .context("failed to build TLS connection pool")?
+        } else {
+            let mgr = Manager::from_config(pg_config, tokio_postgres::NoTls, mgr_config);
+            Pool::builder(mgr)
+                .max_size(self.pool_size)
+                .build()
+                .context("failed to build connection pool")?
+        };
+
+        pools.insert(database.to_string(), pool.clone());
+        Ok(pool)
+    }
+
+    /// Look up the database name for a component.
+    async fn database_for_component(&self, component_id: &str) -> Option<String> {
+        self.component_databases
+            .read()
+            .await
+            .get(component_id)
+            .cloned()
+    }
+}
+
+/// Extract pool_size from URL query params. Returns default if not found.
+fn extract_pool_size(url: &Url) -> usize {
+    url.query_pairs()
+        .find(|(k, _)| k == "pool_size")
+        .and_then(|(_, v)| v.parse().ok())
+        .unwrap_or(DEFAULT_POOL_SIZE)
+}
+
+/// Determine whether TLS is required based on the sslmode URL parameter.
+fn extract_tls_requirement(url: &Url) -> bool {
+    url.query_pairs()
+        .find(|(k, _)| k == "sslmode")
+        .map(|(_, v)| matches!(v.as_ref(), "require" | "verify-ca" | "verify-full"))
+        .unwrap_or(false)
+}
+
+// ── Host trait implementations ──────────────────────────────────────────────
+
+impl<'a> types::Host for ActiveCtx<'a> {}
+
+impl<'a> query::Host for ActiveCtx<'a> {
+    #[instrument(skip_all, fields(query = %q))]
+    async fn query(
+        &mut self,
+        q: String,
+        params: Vec<PgValue>,
+    ) -> anyhow::Result<Result<Vec<query::ResultRow>, QueryError>> {
+        let Some(plugin) = self.get_plugin::<WasmcloudPostgres>(PLUGIN_POSTGRES_ID) else {
+            return Ok(Err(QueryError::Unexpected(
+                "postgres plugin not available".to_string(),
+            )));
+        };
+
+        let component_id = self.component_id.to_string();
+        let database = match plugin.database_for_component(&component_id).await {
+            Some(db) => db,
+            None => {
+                return Ok(Err(QueryError::Unexpected(
+                    "no database configured for this component".to_string(),
+                )));
+            }
+        };
+
+        let pool = match plugin.get_or_create_pool(&database).await {
+            Ok(p) => p,
+            Err(e) => {
+                return Ok(Err(QueryError::Unexpected(format!(
+                    "failed to get connection pool: {e}"
+                ))));
+            }
+        };
+
+        let client = match pool.get().await {
+            Ok(c) => c,
+            Err(e) => {
+                return Ok(Err(QueryError::Unexpected(format!(
+                    "failed to get connection: {e}"
+                ))));
+            }
+        };
+
+        let param_refs: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> = params
+            .iter()
+            .map(|p| p as &(dyn tokio_postgres::types::ToSql + Sync))
+            .collect();
+
+        let rows = match client.query_raw(&q, param_refs).await {
+            Ok(stream) => match stream.try_collect::<Vec<_>>().await {
+                Ok(rows) => rows,
+                Err(e) => {
+                    return Ok(Err(QueryError::Unexpected(format!(
+                        "failed to collect rows: {e}"
+                    ))));
+                }
+            },
+            Err(e) => {
+                return Ok(Err(QueryError::InvalidQuery(format!(
+                    "query execution failed: {e}"
+                ))));
+            }
+        };
+
+        let result: Vec<query::ResultRow> = rows.into_iter().map(into_result_row).collect();
+        Ok(Ok(result))
+    }
+
+    #[instrument(skip_all, fields(query = %q))]
+    async fn query_batch(&mut self, q: String) -> anyhow::Result<Result<(), QueryError>> {
+        let Some(plugin) = self.get_plugin::<WasmcloudPostgres>(PLUGIN_POSTGRES_ID) else {
+            return Ok(Err(QueryError::Unexpected(
+                "postgres plugin not available".to_string(),
+            )));
+        };
+
+        let component_id = self.component_id.to_string();
+        let database = match plugin.database_for_component(&component_id).await {
+            Some(db) => db,
+            None => {
+                return Ok(Err(QueryError::Unexpected(
+                    "no database configured for this component".to_string(),
+                )));
+            }
+        };
+
+        let pool = match plugin.get_or_create_pool(&database).await {
+            Ok(p) => p,
+            Err(e) => {
+                return Ok(Err(QueryError::Unexpected(format!(
+                    "failed to get connection pool: {e}"
+                ))));
+            }
+        };
+
+        let client = match pool.get().await {
+            Ok(c) => c,
+            Err(e) => {
+                return Ok(Err(QueryError::Unexpected(format!(
+                    "failed to get connection: {e}"
+                ))));
+            }
+        };
+
+        match client.batch_execute(&q).await {
+            Ok(()) => Ok(Ok(())),
+            Err(e) => Ok(Err(QueryError::InvalidQuery(format!(
+                "batch execution failed: {e}"
+            )))),
+        }
+    }
+}
+
+impl<'a> prepared::Host for ActiveCtx<'a> {
+    #[instrument(skip_all)]
+    async fn prepare(
+        &mut self,
+        statement: String,
+    ) -> anyhow::Result<Result<String, StatementPrepareError>> {
+        let Some(plugin) = self.get_plugin::<WasmcloudPostgres>(PLUGIN_POSTGRES_ID) else {
+            return Ok(Err(StatementPrepareError::Unexpected(
+                "postgres plugin not available".to_string(),
+            )));
+        };
+
+        let component_id = self.component_id.to_string();
+        let database = match plugin.database_for_component(&component_id).await {
+            Some(db) => db,
+            None => {
+                return Ok(Err(StatementPrepareError::Unexpected(
+                    "no database configured for this component".to_string(),
+                )));
+            }
+        };
+
+        let pool = match plugin.get_or_create_pool(&database).await {
+            Ok(p) => p,
+            Err(e) => {
+                return Ok(Err(StatementPrepareError::Unexpected(format!(
+                    "failed to get connection pool: {e}"
+                ))));
+            }
+        };
+
+        let client = match pool.get().await {
+            Ok(c) => c,
+            Err(e) => {
+                return Ok(Err(StatementPrepareError::Unexpected(format!(
+                    "failed to get connection: {e}"
+                ))));
+            }
+        };
+
+        let stmt = match client.prepare(&statement).await {
+            Ok(s) => s,
+            Err(e) => {
+                return Ok(Err(StatementPrepareError::Unexpected(format!(
+                    "prepare failed: {e}"
+                ))));
+            }
+        };
+
+        let token = ulid::Ulid::new().to_string();
+        let param_types = stmt.params().to_vec();
+
+        plugin.prepared_statements.write().await.insert(
+            token.clone(),
+            PreparedEntry {
+                sql: statement,
+                param_types,
+                database,
+                component_id,
+            },
+        );
+
+        Ok(Ok(token))
+    }
+
+    #[instrument(skip_all, fields(stmt_token = %stmt_token))]
+    async fn exec(
+        &mut self,
+        stmt_token: String,
+        params: Vec<PgValue>,
+    ) -> anyhow::Result<Result<u64, PreparedStatementExecError>> {
+        let Some(plugin) = self.get_plugin::<WasmcloudPostgres>(PLUGIN_POSTGRES_ID) else {
+            return Ok(Err(PreparedStatementExecError::Unexpected(
+                "postgres plugin not available".to_string(),
+            )));
+        };
+
+        let entry = {
+            let stmts = plugin.prepared_statements.read().await;
+            match stmts.get(&stmt_token) {
+                Some(entry) => PreparedEntry {
+                    sql: entry.sql.clone(),
+                    param_types: entry.param_types.clone(),
+                    database: entry.database.clone(),
+                    component_id: entry.component_id.clone(),
+                },
+                None => return Ok(Err(PreparedStatementExecError::UnknownPreparedQuery)),
+            }
+        };
+
+        let pool = match plugin.get_or_create_pool(&entry.database).await {
+            Ok(p) => p,
+            Err(e) => {
+                return Ok(Err(PreparedStatementExecError::Unexpected(format!(
+                    "failed to get connection pool: {e}"
+                ))));
+            }
+        };
+
+        let client = match pool.get().await {
+            Ok(c) => c,
+            Err(e) => {
+                return Ok(Err(PreparedStatementExecError::Unexpected(format!(
+                    "failed to get connection: {e}"
+                ))));
+            }
+        };
+
+        // Re-prepare via statement cache (deadpool-postgres caches these per connection)
+        let stmt = match client.prepare_typed(&entry.sql, &entry.param_types).await {
+            Ok(s) => s,
+            Err(e) => {
+                return Ok(Err(PreparedStatementExecError::Unexpected(format!(
+                    "re-prepare failed: {e}"
+                ))));
+            }
+        };
+
+        let param_refs: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> = params
+            .iter()
+            .map(|p| p as &(dyn tokio_postgres::types::ToSql + Sync))
+            .collect();
+
+        match client.execute_raw(&stmt, param_refs).await {
+            Ok(n) => Ok(Ok(n)),
+            Err(e) => Ok(Err(PreparedStatementExecError::QueryError(
+                QueryError::Unexpected(format!("execute failed: {e}")),
+            ))),
+        }
+    }
+}
+
+// ── HostPlugin implementation ───────────────────────────────────────────────
+
+#[async_trait::async_trait]
+impl HostPlugin for WasmcloudPostgres {
+    fn id(&self) -> &'static str {
+        PLUGIN_POSTGRES_ID
+    }
+
+    fn world(&self) -> WitWorld {
+        WitWorld {
+            imports: HashSet::from([WitInterface::from(
+                "wasmcloud:postgres/types,query,prepared@0.1.1-draft",
+            )]),
+            ..Default::default()
+        }
+    }
+
+    async fn start(&self) -> anyhow::Result<()> {
+        let pools = Arc::clone(&self.pools);
+        let component_databases = Arc::clone(&self.component_databases);
+        let notify = Arc::clone(&self.pool_reaper_notify);
+
+        tokio::spawn(async move {
+            loop {
+                notify.notified().await;
+                // Grace period: let rapid restarts re-bind before we clean up
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+                // Determine which databases are still in use
+                let in_use: HashSet<String> =
+                    component_databases.read().await.values().cloned().collect();
+
+                // Remove pools for databases with no remaining components
+                let mut pools_lock = pools.write().await;
+                pools_lock.retain(|db, _| {
+                    let keep = in_use.contains(db);
+                    if !keep {
+                        tracing::debug!(database = %db, "Removing idle connection pool");
+                    }
+                    keep
+                });
+            }
+        });
+
+        Ok(())
+    }
+
+    async fn on_workload_item_bind<'a>(
+        &self,
+        component_handle: &mut WorkloadItem<'a>,
+        interfaces: HashSet<WitInterface>,
+    ) -> anyhow::Result<()> {
+        let database = match interfaces
+            .iter()
+            .find(|i| i.namespace == "wasmcloud" && i.package == "postgres")
+        {
+            Some(i) => match i.config.get("database").cloned() {
+                Some(db) => db,
+                None => bail!("wasmcloud:postgres requires a 'database' config parameter"),
+            },
+            None => return Ok(()),
+        };
+
+        let component_id = component_handle.id().to_string();
+
+        tracing::debug!(
+            component_id = %component_id,
+            database = %database,
+            "Binding postgres plugin to component"
+        );
+
+        // Store the component → database mapping
+        self.component_databases
+            .write()
+            .await
+            .insert(component_id, database);
+
+        // Add linker functions
+        let linker = component_handle.linker();
+        bindings::wasmcloud::postgres::types::add_to_linker::<_, SharedCtx>(
+            linker,
+            extract_active_ctx,
+        )?;
+        bindings::wasmcloud::postgres::query::add_to_linker::<_, SharedCtx>(
+            linker,
+            extract_active_ctx,
+        )?;
+        bindings::wasmcloud::postgres::prepared::add_to_linker::<_, SharedCtx>(
+            linker,
+            extract_active_ctx,
+        )?;
+
+        Ok(())
+    }
+
+    async fn on_workload_unbind(
+        &self,
+        workload_id: &str,
+        _interfaces: HashSet<WitInterface>,
+    ) -> anyhow::Result<()> {
+        tracing::debug!(workload_id = %workload_id, "Unbinding postgres plugin from workload");
+
+        // Remove component → database mappings for this workload
+        let removed_components: Vec<String> = {
+            let mut component_databases = self.component_databases.write().await;
+            let removed: Vec<String> = component_databases
+                .keys()
+                .filter(|k| k.starts_with(workload_id))
+                .cloned()
+                .collect();
+            for c in &removed {
+                component_databases.remove(c);
+            }
+            removed
+        };
+
+        // Clean up prepared statements by component_id (not database)
+        if !removed_components.is_empty() {
+            let mut prepared = self.prepared_statements.write().await;
+            prepared.retain(|_, entry| !removed_components.contains(&entry.component_id));
+        }
+
+        // Signal the pool reaper to check for idle pools
+        self.pool_reaper_notify.notify_one();
+
+        Ok(())
+    }
+}

--- a/crates/wash-runtime/tests/fixtures/http-counter/src/lib.rs
+++ b/crates/wash-runtime/tests/fixtures/http-counter/src/lib.rs
@@ -15,14 +15,14 @@ use bindings::{
         },
         config::store::get_all,
         http::{
-            outgoing_handler::{handle, OutgoingRequest, RequestOptions},
+            outgoing_handler::{OutgoingRequest, RequestOptions, handle},
             types::{
                 Fields, IncomingRequest, Method, OutgoingBody, OutgoingResponse, ResponseOutparam,
                 Scheme,
             },
         },
         keyvalue::{atomics::increment, store::open},
-        logging::logging::{log, Level},
+        logging::logging::{Level, log},
     },
 };
 
@@ -36,7 +36,11 @@ impl Guest for Component {
     fn handle(_request: IncomingRequest, response_out: ResponseOutparam) {
         match handle_request() {
             Ok(count) => {
-                log(Level::Info, "", &format!("Successfully processed request, count: {count}"));
+                log(
+                    Level::Info,
+                    "",
+                    &format!("Successfully processed request, count: {count}"),
+                );
                 let response = OutgoingResponse::new(Fields::new());
                 response.set_status_code(200).unwrap();
                 let body = response.body().unwrap();
@@ -56,7 +60,9 @@ impl Guest for Component {
 
                 let error_msg = format!("Internal server error: {e}");
                 let stream = body.write().unwrap();
-                stream.blocking_write_and_flush(error_msg.as_bytes()).unwrap();
+                stream
+                    .blocking_write_and_flush(error_msg.as_bytes())
+                    .unwrap();
                 drop(stream);
                 OutgoingBody::finish(body, None).unwrap();
             }
@@ -91,19 +97,27 @@ fn log_runtime_config() -> Result<()> {
             }
         }
         Err(e) => {
-            log(Level::Warn, "", &format!("Failed to retrieve runtime configuration: {e:?}"));
+            log(
+                Level::Warn,
+                "",
+                &format!("Failed to retrieve runtime configuration: {e:?}"),
+            );
         }
     }
     Ok(())
 }
 
 fn make_outgoing_request() -> Result<String> {
-    log(Level::Info, "", "Making outgoing HTTP request to https://example.com");
+    log(
+        Level::Info,
+        "",
+        "Making outgoing HTTP request to http://example.com",
+    );
 
     let request = OutgoingRequest::new(Fields::new());
     request
-        .set_scheme(Some(&Scheme::Https))
-        .map_err(|_| anyhow::anyhow!("Failed to set HTTPS scheme"))?;
+        .set_scheme(Some(&Scheme::Http))
+        .map_err(|_| anyhow::anyhow!("Failed to set HTTP scheme"))?;
     request
         .set_authority(Some("example.com"))
         .map_err(|_| anyhow::anyhow!("Failed to set authority"))?;
@@ -127,10 +141,18 @@ fn make_outgoing_request() -> Result<String> {
         .map_err(|e| anyhow::anyhow!("Request failed: {e:?}"))??;
 
     let status = incoming_response.status();
-    log(Level::Info, "", &format!("Received response with status: {status}"));
+    log(
+        Level::Info,
+        "",
+        &format!("Received response with status: {status}"),
+    );
 
     if status < 200 || status >= 300 {
-        log(Level::Warn, "", &format!("Non-success status code received: {status}"));
+        log(
+            Level::Warn,
+            "",
+            &format!("Non-success status code received: {status}"),
+        );
     }
 
     let body_stream = incoming_response
@@ -155,21 +177,37 @@ fn make_outgoing_request() -> Result<String> {
     }
 
     let body_string = String::from_utf8_lossy(&body_data).to_string();
-    log(Level::Info, "", &format!("Retrieved {} bytes from example.com", body_data.len()));
+    log(
+        Level::Info,
+        "",
+        &format!("Retrieved {} bytes from example.com", body_data.len()),
+    );
 
     Ok(body_string)
 }
 
 fn store_response_in_blobstore(response_body: &str) -> Result<()> {
-    log(Level::Info, "", &format!("Storing response in blobstore container: {CONTAINER_NAME}"));
+    log(
+        Level::Info,
+        "",
+        &format!("Storing response in blobstore container: {CONTAINER_NAME}"),
+    );
 
     let container = match get_container(CONTAINER_NAME) {
         Ok(container) => {
-            log(Level::Info, "", &format!("Using existing container: {CONTAINER_NAME}"));
+            log(
+                Level::Info,
+                "",
+                &format!("Using existing container: {CONTAINER_NAME}"),
+            );
             container
         }
         Err(_) => {
-            log(Level::Info, "", &format!("Creating new container: {CONTAINER_NAME}"));
+            log(
+                Level::Info,
+                "",
+                &format!("Creating new container: {CONTAINER_NAME}"),
+            );
             create_container(CONTAINER_NAME)
                 .map_err(|e| anyhow::anyhow!("Failed to create blobstore container: {e}"))?
         }
@@ -193,7 +231,14 @@ fn store_response_in_blobstore(response_body: &str) -> Result<()> {
 
     OutgoingValue::finish(outgoing_value).ok();
 
-    log(Level::Info, "", &format!("Successfully stored {} bytes in object: {OBJECT_KEY}", response_bytes.len()));
+    log(
+        Level::Info,
+        "",
+        &format!(
+            "Successfully stored {} bytes in object: {OBJECT_KEY}",
+            response_bytes.len()
+        ),
+    );
 
     Ok(())
 }
@@ -205,7 +250,11 @@ fn increment_counter() -> Result<u64> {
 
     let new_count = increment(&bucket, COUNTER_KEY, 1).context("Failed to increment counter")?;
 
-    log(Level::Info, "", &format!("Request count incremented to: {new_count}"));
+    log(
+        Level::Info,
+        "",
+        &format!("Request count incremented to: {new_count}"),
+    );
 
     Ok(new_count)
 }

--- a/crates/wash-runtime/wit/deps/wasmcloud-postgres-0.1.1-draft/package.wit
+++ b/crates/wash-runtime/wit/deps/wasmcloud-postgres-0.1.1-draft/package.wit
@@ -1,0 +1,339 @@
+package wasmcloud:postgres@0.1.1-draft;
+
+/// Types used by components and providers of a SQLDB Postgres interface
+interface types {
+  /// Errors that occur while executing queries
+  variant query-error {
+    /// Unknown/invalid query parameters
+    invalid-params(string),
+    /// Invalid/malformed query
+    invalid-query(string),
+    /// A completely unexpected error, specific to executing queries
+    unexpected(string),
+  }
+
+  /// Errors that occur while preparing a statement
+  variant statement-prepare-error {
+    /// A completely unexpected error
+    unexpected(string),
+  }
+
+  /// Errors that occur during prepared statement execution
+  variant prepared-statement-exec-error {
+    /// Unknown/invalid prepared statement token
+    unknown-prepared-query,
+    /// An otherwise known query execution error
+    query-error(query-error),
+    /// A completely unexpected error, specific to prepared statements
+    unexpected(string),
+  }
+
+  /// This type of floating point is necessary as rust does not allow Eq/PartialEq/Hash on real `f64`
+  /// Instead we use a sign + mantissa + exponent
+  ///
+  /// see: https://docs.rs/num/latest/num/trait.Float.html#tymethod.integer_decode
+  type hashable-f64 = tuple<u64, s16, s8>;
+
+  type hashable-f32 = hashable-f64;
+
+  type point = tuple<hashable-f64, hashable-f64>;
+
+  type lower-left-point = point;
+
+  type upper-right-point = point;
+
+  type start-point = point;
+
+  type end-point = point;
+
+  type center-point = point;
+
+  type radius = hashable-f64;
+
+  type ipv4-addr = string;
+
+  type ipv6-addr = string;
+
+  type subnet = string;
+
+  type xmin = s64;
+
+  type xmax = s64;
+
+  type xip-list = list<s64>;
+
+  type logfile-num = u32;
+
+  type logfile-byte-offset = u32;
+
+  type column-name = string;
+
+  /// Arbitrary precision numeric type
+  type numeric = string;
+
+  /// Chosen weight of a Lexeme
+  enum lexeme-weight {
+    A,
+    B,
+    C,
+    D,
+  }
+
+  /// Represents an arbitrary precision numeric type
+  record lexeme {
+    /// Position (1->16383)
+    position: option<u16>,
+    /// Weight of the lexeme (in a relevant ts-vector)
+    weight: option<lexeme-weight>,
+    /// Data
+    data: string,
+  }
+
+  /// Offsets are expressed in seconds of timezone difference in either from the
+  /// eastern hemisphere or western hemisphere.
+  ///
+  /// ex. "America/New York", which is UTC-4 can be expressed as western-hemisphere-secs(4 * 3600)
+  variant offset {
+    eastern-hemisphere-secs(s32),
+    western-hemisphere-secs(s32),
+  }
+
+  /// Dates are represented similarly to tokio-postgres implementation
+  /// see: https://docs.rs/postgres-types/0.2.6/postgres_types/enum.Date.html#variant.Value
+  variant date {
+    positive-infinity,
+    negative-infinity,
+    ymd(tuple<s32, u32, u32>),
+  }
+
+  record interval {
+    start: date,
+    start-inclusive: bool,
+    end: date,
+    end-inclusive: bool,
+  }
+
+  record time {
+    hour: u32,
+    min: u32,
+    sec: u32,
+    micro: u32,
+  }
+
+  record time-tz {
+    timesonze: string,
+    time: time,
+  }
+
+  record timestamp {
+    date: date,
+    time: time,
+  }
+
+  record timestamp-tz {
+    timestamp: timestamp,
+    offset: offset,
+  }
+
+  record mac-address-eui48 {
+    bytes: tuple<u8, u8, u8, u8, u8, u8>,
+  }
+
+  record mac-address-eui64 {
+    bytes: tuple<u8, u8, u8, u8, u8, u8, u8, u8>,
+  }
+
+  /// Postgres data values, usable as parameters or via queries
+  /// see: https://www.postgresql.org/docs/current/datatype.html
+  ///
+  /// This datatype is primarily intended to be used with the `raw` encoding scheme.
+  ///
+  /// NOTE: all numeric values are little-endian unless otherwise specified
+  variant pg-value {
+    null,
+    /// Numeric
+    big-int(s64),
+    int8(s64),
+    int8-array(list<s64>),
+    big-serial(s64),
+    serial8(s64),
+    %bool(bool),
+    boolean(bool),
+    bool-array(list<bool>),
+    double(hashable-f64),
+    float8(hashable-f64),
+    float8-array(list<hashable-f64>),
+    real(hashable-f32),
+    float4(hashable-f32),
+    float4-array(list<hashable-f32>),
+    integer(s32),
+    int(s32),
+    int4(s32),
+    int4-array(list<s32>),
+    numeric(numeric),
+    decimal(numeric),
+    numeric-array(list<numeric>),
+    serial(u32),
+    serial4(u32),
+    small-int(s16),
+    int2(s16),
+    int2-array(list<s16>),
+    int2-vector(list<s16>),
+    int2-vector-array(list<list<s16>>),
+    small-serial(s16),
+    serial2(s16),
+    /// note: matches tokio-postgres
+    /// Bytes
+    ///
+    /// For bit & bit-varying, see the encoding scheme used by bit-vec:
+    /// https://contain-rs.github.io/bit-vec/bit_vec/struct.BitVec.html#method.to_bytes
+    bit(tuple<u32, list<u8>>),
+    bit-array(list<tuple<u32, list<u8>>>),
+    bit-varying(tuple<option<u32>, list<u8>>),
+    varbit(tuple<option<u32>, list<u8>>),
+    varbit-array(list<tuple<option<u32>, list<u8>>>),
+    bytea(list<u8>),
+    bytea-array(list<list<u8>>),
+    /// Characters
+    /// TODO: specify text encoding, to negotiate possible component/DB mismatch?
+    %char(tuple<u32, list<u8>>),
+    char-array(list<tuple<u32, list<u8>>>),
+    varchar(tuple<option<u32>, list<u8>>),
+    varchar-array(list<tuple<option<u32>, list<u8>>>),
+    /// Networking
+    cidr(string),
+    cidr-array(list<string>),
+    inet(string),
+    inet-array(list<string>),
+    macaddr(mac-address-eui48),
+    /// EUI-48
+    macaddr-array(list<mac-address-eui48>),
+    /// EUI-48
+    macaddr8(mac-address-eui64),
+    /// EUI-64 (deprecated)
+    macaddr8-array(list<mac-address-eui64>),
+    /// EUI-64 (deprecated)
+    /// Geo
+    box(tuple<lower-left-point, upper-right-point>),
+    box-array(list<tuple<lower-left-point, upper-right-point>>),
+    circle(tuple<center-point, radius>),
+    circle-array(list<tuple<center-point, radius>>),
+    line(tuple<start-point, end-point>),
+    line-array(list<tuple<start-point, end-point>>),
+    lseg(tuple<start-point, end-point>),
+    lseg-array(list<tuple<start-point, end-point>>),
+    path(list<point>),
+    path-array(list<list<point>>),
+    point(point),
+    point-array(list<point>),
+    polygon(list<point>),
+    polygon-array(list<list<point>>),
+    /// Date-time
+    date(date),
+    date-array(list<date>),
+    interval(interval),
+    interval-array(list<interval>),
+    time(time),
+    time-array(list<time>),
+    time-tz(time-tz),
+    time-tz-array(list<time-tz>),
+    timestamp(timestamp),
+    timestamp-array(list<timestamp>),
+    timestamp-tz(timestamp-tz),
+    timestamp-tz-array(list<timestamp-tz>),
+    /// JSON
+    json(string),
+    json-array(list<string>),
+    jsonb(string),
+    jsonb-array(list<string>),
+    /// Money (use is discouraged)
+    ///
+    /// fractional precision is determined by the database's `lc_monetary` setting.
+    ///
+    /// NOTE: if you are storing currency amounts, consider
+    /// using integer (whole number) counts of smallest indivisible pieces of currency
+    /// (ex. cent amounts to represent United States Dollars; 100 cents = 1 USD)
+    money(numeric),
+    money-array(list<numeric>),
+    /// Postgres-internal
+    pg-lsn(u64),
+    pg-lsn-array(list<u64>),
+    /// see: https://www.postgresql.org/docs/current/functions-info.html#FUNCTIONS-PG-SNAPSHOT-PARTS
+    pg-snapshot(tuple<xmin, xmax, xip-list>),
+    txid-snapshot(s64),
+    /// Text
+    name(string),
+    name-array(list<string>),
+    text(string),
+    text-array(list<string>),
+    xml(string),
+    xml-array(list<string>),
+    /// Full Text Search
+    ts-query(string),
+    ts-vector(list<lexeme>),
+    /// UUIDs
+    uuid(string),
+    uuid-array(list<string>),
+    /// Containers
+    hstore(list<tuple<string, option<string>>>),
+  }
+
+  record result-row-entry {
+    /// Name of the result column
+    column-name: string,
+    /// Value of the result column
+    value: pg-value,
+  }
+
+  type result-row = list<result-row-entry>;
+}
+
+/// Interface for querying a Postgres database
+interface query {
+  use types.{pg-value, result-row, query-error};
+
+  /// Query a Postgres database, leaving connection/session management
+  /// to the callee/implementer of this interface (normally a provider configured with connection credentials)
+  ///
+  /// Queries *must* be parameterized, with named arguments in the form of `$<integer>`, for example:
+  ///
+  /// ```
+  /// SELECT email,username FROM users WHERE uuid=$1;
+  /// ```
+  query: func(query: string, params: list<pg-value>) -> result<list<result-row>, query-error>;
+
+  /// Perform a batch query (which could contain multiple statements) against a Postgres database,
+  /// leaving connection/session management to the callee/implementer of this interface
+  /// (normally a provider configured with connection credentials)
+  ///
+  /// No user-provided or untrusted data should be used with this query -- parameters are not allowed
+  ///
+  /// This query *can* be used to execute multi-statement queries (common in migrations).
+  query-batch: func(query: string) -> result<_, query-error>;
+}
+
+/// Interface for querying a Postgres database with prepared statements
+interface prepared {
+  use types.{pg-value, result-row, statement-prepare-error, prepared-statement-exec-error};
+
+  /// A token that represents a previously created prepared statement,
+  ///
+  /// This token can be expected to be somewhat opaque to users.
+  type prepared-statement-token = string;
+
+  /// Prepare a statement, given a connection token (which can represent a connection *or* session),
+  /// to a Postgres database.
+  ///
+  /// Queries *must* be parameterized, with named arguments in the form of `$<integer>`, for example:
+  ///
+  /// ```
+  /// SELECT email,username FROM users WHERE uuid=$1;
+  /// ```
+  ///
+  /// NOTE: To see how to obtain a `connection-token`, see `connection.wit`.
+  prepare: func(statement: string) -> result<prepared-statement-token, statement-prepare-error>;
+
+  /// Execute a prepared statement, returning the number of rows affected
+  exec: func(stmt-token: prepared-statement-token, params: list<pg-value>) -> result<u64, prepared-statement-exec-error>;
+}
+

--- a/crates/wash-runtime/wit/world.wit
+++ b/crates/wash-runtime/wit/world.wit
@@ -26,6 +26,13 @@ world blobstore {
 }
 
 world messaging {
+    import wasmcloud:messaging/types@0.2.0;
     import wasmcloud:messaging/consumer@0.2.0;
     export wasmcloud:messaging/handler@0.2.0;
+}
+
+world postgres {
+  import wasmcloud:postgres/types@0.1.1-draft;
+  import wasmcloud:postgres/query@0.1.1-draft;
+  import wasmcloud:postgres/prepared@0.1.1-draft;
 }

--- a/crates/wash-runtime/wkg.lock
+++ b/crates/wash-runtime/wkg.lock
@@ -55,3 +55,12 @@ registry = "wasmcloud.com"
 requirement = "=0.2.0"
 version = "0.2.0"
 digest = "sha256:bd2182f0a304b9a54a6b363f2f655422c8c0f00a03073c0195f1614a92dfdc7b"
+
+[[packages]]
+name = "wasmcloud:postgres"
+registry = "wasmcloud.com"
+
+[[packages.versions]]
+requirement = "=0.1.1-draft"
+version = "0.1.1-draft"
+digest = "sha256:8bb72ea90cecb5c87e463da8c1a7642b61a44e6c7993fcab6112c03f44a9140a"

--- a/crates/wash/Cargo.toml
+++ b/crates/wash/Cargo.toml
@@ -55,7 +55,7 @@ uuid = { workspace = true }
 wasm-metadata = { workspace = true }
 wasm-pkg-client = { workspace = true }
 wasm-pkg-core = { workspace = true }
-wash-runtime = { workspace = true, features = ["washlet", "oci", "wasi-config", "wasi-logging", "wasi-blobstore", "wasi-keyvalue"] }
+wash-runtime = { workspace = true, features = ["washlet", "oci", "wasi-config", "wasi-logging", "wasi-blobstore", "wasi-keyvalue", "wasmcloud-postgres"] }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
 wit-component = { workspace = true }

--- a/crates/wash/src/cli/dev.rs
+++ b/crates/wash/src/cli/dev.rs
@@ -144,6 +144,15 @@ impl CliCommand for DevCommand {
             debug!("WASI KeyValue plugin registered with in-memory backend");
         }
 
+        // Add postgres plugin if configured
+        if let Some(postgres_url) = &dev_config.postgres_url {
+            host_builder = host_builder.with_plugin(Arc::new(
+                plugin::wasmcloud_postgres::WasmcloudPostgres::new(postgres_url)
+                    .context("failed to configure postgres plugin")?,
+            ))?;
+            debug!("wasmcloud:postgres plugin registered");
+        }
+
         // Enable WASI WebGPU if requested
         #[cfg(not(target_os = "windows"))]
         if dev_config.wasi_webgpu {

--- a/crates/wash/src/config.rs
+++ b/crates/wash/src/config.rs
@@ -178,6 +178,11 @@ pub struct DevConfig {
     /// Optional path for WASI blobstore filesystem storage. If not set, an in-memory store is used.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wasi_blobstore_path: Option<PathBuf>,
+
+    /// Optional PostgreSQL connection URL for the wasmcloud:postgres plugin.
+    /// Example: postgres://user:pass@bouncer:6432?sslmode=require&pool_size=10
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub postgres_url: Option<String>,
 }
 
 /// Load configuration with hierarchical merging


### PR DESCRIPTION
Porting https://github.com/wasmCloud/wasmCloud/tree/main/crates/provider-sqldb-postgres to v2

We can't use v1's example as it performs a direct call into the component via `wash call`.

Validated manually with a combination of existing postgresql example + http hello world.
<img width="762" height="579" alt="Screenshot 2026-02-09 at 2 52 19 PM" src="https://github.com/user-attachments/assets/c45280fc-2d53-460d-8b9f-3a565dcf1be1" />
<img width="877" height="676" alt="Screenshot 2026-02-09 at 2 51 40 PM" src="https://github.com/user-attachments/assets/61703b72-20d9-4395-b78b-f8b9c47ed403" />
