### PR TITLE
fix: paths in OCI & WIT subcommands

### DIFF
--- a/crates/wash/src/cli/mod.rs
+++ b/crates/wash/src/cli/mod.rs
@@ -408,8 +408,10 @@ impl CliContextBuilder {
             .start()
             .await?;
 
-        let original_working_dir =
-            std::env::current_dir().context("failed to get current working directory")?;
+        let original_working_dir = std::env::current_dir()
+            .ok()
+            .or_else(|| self.project_dir.clone())
+            .context("failed to get current working directory and no project dir specified")?;
 
         let project_dir = match &self.project_dir {
             Some(dir) => dir.clone(),

--- a/crates/wash/src/cli/oci.rs
+++ b/crates/wash/src/cli/oci.rs
@@ -85,7 +85,7 @@ impl PullCommand {
         let component_path = if self.component_path.is_absolute() {
             self.component_path.clone()
         } else {
-            ctx.project_dir().join(&self.component_path)
+            ctx.original_working_dir().join(&self.component_path)
         };
 
         // Write the component to the specified output path
@@ -133,7 +133,7 @@ impl PushCommand {
         let component_path = if self.component_path.is_absolute() {
             self.component_path.clone()
         } else {
-            ctx.project_dir().join(&self.component_path)
+            ctx.original_working_dir().join(&self.component_path)
         };
 
         let component = tokio::fs::read(&component_path)

--- a/crates/wash/src/cli/wit.rs
+++ b/crates/wash/src/cli/wit.rs
@@ -792,7 +792,11 @@ async fn handle_build(
 
     // Determine output path
     let output_path = if let Some(output) = output_override {
-        output.to_path_buf()
+        if output.is_absolute() {
+            output.to_path_buf()
+        } else {
+            ctx.original_working_dir().join(output)
+        }
     } else {
         // Default to project root: <package-name>-<version>.wasm or <package-name>.wasm
         let filename = if let Some(ver) = &version {


### PR DESCRIPTION
closes #281

we now stash the original directory and use it in `wit` and `oci` subcommands.

This bug used to manifest when running `wash oci pull` in a project's subdirectory or detached from a wash project.