### PR TITLE
fix(wash-runtime): enable component-model feature for wat in dev-dependencies (#299)

### DIFF
--- a/crates/wash-runtime/Cargo.toml
+++ b/crates/wash-runtime/Cargo.toml
@@ -119,5 +119,5 @@ pbjson-build = { workspace = true, default-features = true }
 tokio = { workspace = true, features = ["full"] }
 tracing-subscriber = { workspace = true }
 reqwest = { workspace = true }
-wat = { workspace = true }
+wat = { workspace = true, features = ["component-model"] }
 gag = "1.0"


### PR DESCRIPTION
Fixes issue wasmCloud/wasmCloud#4933.

The `wat` crate was declared in the workspace with `default-features = false`, which disables component parsing support.
Two tests in `wash-runtime` use `wat::parse_str` with `(component ...)` syntax and panicked at runtime:

- `host::tests::test_extract_component_interfaces_with_http_export`
- `host::tests::test_extract_component_interfaces_no_interfaces`

Adding `features = ["component-model"]` to `wat` in `wash-runtime`'s dev-dependencies fixes both failures.